### PR TITLE
Core library made available to C++ and other improvements:

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ Written by:
   Iban Cereijo <ibancg@gmail.com>
   Jairo Chapela <jairochapela@gmail.com>
 
-Copyright (C) 2004-2019 Iban Cereijo
+Copyright (C) 2004-2020 Iban Cereijo
 Copyright (C) 2004-2019 Jairo Chapela
 
 

--- a/src/lingot-audio-alsa.h
+++ b/src/lingot-audio-alsa.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,11 +29,19 @@
 
 #include <alsa/asoundlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     snd_pcm_t *capture_handle;
-} LingotAudioHandlerExtraALSA;
+} lingot_audio_handler_alsa_t;
 
 int lingot_audio_alsa_register(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 #endif

--- a/src/lingot-audio-jack.c
+++ b/src/lingot-audio-jack.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -48,16 +48,16 @@ static char last_ports[MAX_LAST_PORTS][80];
 // JACK calls this shutdown_callback if the server ever shuts down or
 // decides to disconnect the client.
 void lingot_audio_jack_shutdown(void* param) {
-    LingotAudioHandler* audio = param;
+    lingot_audio_handler_t* audio = param;
     lingot_msg_add_error(_("Missing connection with JACK audio server"));
     pthread_mutex_lock(&stop_mutex);
     audio->interrupted = 1;
     pthread_mutex_unlock(&stop_mutex);
 }
 
-void lingot_audio_jack_new(LingotAudioHandler* audio, const char* device, int sample_rate) {
+void lingot_audio_jack_new(lingot_audio_handler_t* audio, const char* device, int sample_rate) {
     (void) sample_rate; // unused
-    const char* exception;
+    const char* _exception;
     //	const char **ports = NULL;
     const char *client_name = "lingot";
     const char *server_name = NULL;
@@ -68,16 +68,16 @@ void lingot_audio_jack_new(LingotAudioHandler* audio, const char* device, int sa
     strcpy(audio->device, "");
 
     audio->bytes_per_sample = -1;
-    audio->audio_handler_extra = malloc(sizeof(LingotAudioHandlerExtraJack));
-    LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+    audio->audio_handler_extra = malloc(sizeof(lingot_audio_handler_jack_t));
+    lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
 
     audioJack->client = jack_client_open(client_name, options, &status,
                                          server_name);
 
-    try
+    _try
     {
         if (audioJack->client == NULL) {
-            throw(_("Unable to connect to JACK server"));
+            _throw(_("Unable to connect to JACK server"));
         }
 
         if (status & JackServerStarted) {
@@ -103,14 +103,14 @@ void lingot_audio_jack_new(LingotAudioHandler* audio, const char* device, int sa
                                                    JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
 
         if (audioJack->input_port == NULL) {
-            throw(_("No more JACK ports available"));
+            _throw(_("No more JACK ports available"));
         }
 
         snprintf(audio->device, sizeof(audio->device), "%s", device);
 
-    }catch {
+    } _catch {
         audio->audio_system = -1;
-        lingot_msg_add_error(exception);
+        lingot_msg_add_error(_exception);
     }
 
     if (audio->audio_system >= 0) {
@@ -118,20 +118,21 @@ void lingot_audio_jack_new(LingotAudioHandler* audio, const char* device, int sa
     }
 }
 
-void lingot_audio_jack_destroy(LingotAudioHandler* audio) {
+void lingot_audio_jack_destroy(lingot_audio_handler_t* audio) {
     if (audio->audio_system >= 0) {
-        LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+        lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
         //jack_cycle_wait(audio->jack_client);
         //		jack_deactivate(audio->jack_client);
         jack_client_close(audioJack->client);
         client = NULL;
         free(audio->audio_handler_extra);
+        audio->audio_handler_extra = NULL;
     }
 }
 
-int lingot_audio_jack_read(LingotAudioHandler* audio) {
+int lingot_audio_jack_read(lingot_audio_handler_t* audio) {
     jack_nframes_t i;
-    LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+    lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
     float* in = jack_port_get_buffer(audioJack->input_port, audioJack->nframes);
     for (i = 0; i < audioJack->nframes; i++) {
         audio->flt_read_buffer[i] = in[i] * FLT_SAMPLE_SCALE;
@@ -140,8 +141,8 @@ int lingot_audio_jack_read(LingotAudioHandler* audio) {
 }
 
 int lingot_audio_jack_process(jack_nframes_t nframes, void* param) {
-    LingotAudioHandler* audio = param;
-    LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+    lingot_audio_handler_t* audio = param;
+    lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
     audioJack->nframes = nframes;
 
     pthread_mutex_lock(&stop_mutex);
@@ -156,7 +157,7 @@ int lingot_audio_jack_process(jack_nframes_t nframes, void* param) {
 }
 
 int lingot_audio_jack_get_audio_system_properties(
-        LingotAudioSystemProperties* properties) {
+        lingot_audio_system_properties_t* properties) {
     int sample_rate = -1;
 
     const char *client_name = "lingot-get-audio-properties";
@@ -166,7 +167,7 @@ int lingot_audio_jack_get_audio_system_properties(
     jack_status_t status;
     jack_client_t* jack_client = NULL;
     const char **ports = NULL;
-    const char* exception;
+    const char* _exception;
 
     unsigned long int flags = JackPortIsOutput;
 
@@ -174,13 +175,13 @@ int lingot_audio_jack_get_audio_system_properties(
     properties->n_devices = 0;
     properties->devices = NULL;
 
-    try
+    _try
     {
         if (client == NULL) {
             jack_client = jack_client_open(client_name, options, &status,
                                            server_name);
             if (jack_client == NULL) {
-                throw(_("Unable to connect to JACK server"));
+                _throw(_("Unable to connect to JACK server"));
             }
             if (status & JackServerStarted) {
                 fprintf(stderr, "JACK server started\n");
@@ -194,11 +195,11 @@ int lingot_audio_jack_get_audio_system_properties(
             ports = jack_get_ports(client, NULL, NULL, flags);
         }
 
-    }catch {
+    } _catch {
         // here I throw a warning message because we are only ontaining the
         // audio properties
         //		lingot_msg_add_warning(exception);
-        fprintf(stderr, "%s", exception);
+        fprintf(stderr, "%s", _exception);
     }
 
     properties->forced_sample_rate = 1;
@@ -242,8 +243,8 @@ int lingot_audio_jack_get_audio_system_properties(
     return 0;
 }
 
-void lingot_audio_jack_stop(LingotAudioHandler* audio) {
-    LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+void lingot_audio_jack_stop(lingot_audio_handler_t* audio) {
+    lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
     //jack_cycle_wait(audioJack->jack_client);
     const char** ports = jack_get_ports(audioJack->client, NULL, NULL,
                                         JackPortIsOutput);
@@ -268,25 +269,25 @@ void lingot_audio_jack_stop(LingotAudioHandler* audio) {
     pthread_mutex_unlock(&stop_mutex);
 }
 
-int lingot_audio_jack_start(LingotAudioHandler* audio) {
+int lingot_audio_jack_start(lingot_audio_handler_t* audio) {
     int result = 0;
     int index = 0;
     const char **ports = NULL;
-    const char* exception;
-    LingotAudioHandlerExtraJack* audioJack = (LingotAudioHandlerExtraJack*) audio->audio_handler_extra;
+    const char* _exception;
+    lingot_audio_handler_jack_t* audioJack = (lingot_audio_handler_jack_t*) audio->audio_handler_extra;
     jack_set_process_callback(audioJack->client, lingot_audio_jack_process,
                               audio);
 
-    try
+    _try
     {
         if (jack_activate(audioJack->client)) {
-            throw(_("Cannot activate client"));
+            _throw(_("Cannot activate client"));
         }
 
         ports = jack_get_ports(audioJack->client, NULL, NULL,
                                JackPortIsOutput);
         if (ports == NULL) {
-            throw(_("No active capture ports"));
+            _throw(_("No active capture ports"));
         }
 
         if (!strcmp(audio->device, "default")) {
@@ -298,7 +299,7 @@ int lingot_audio_jack_start(LingotAudioHandler* audio) {
                     if (!strcmp(last_ports[j], ports[index])) {
                         if (jack_connect(audioJack->client, ports[index],
                                          jack_port_name(audioJack->input_port))) {
-                            throw(_("Cannot connect input ports"));
+                            _throw(_("Cannot connect input ports"));
                         } else {
                             connections++;
                         }
@@ -311,7 +312,7 @@ int lingot_audio_jack_start(LingotAudioHandler* audio) {
             if (!connections) {
                 if (jack_connect(audioJack->client, ports[0],
                                  jack_port_name(audioJack->input_port))) {
-                    throw(_("Cannot connect input ports"));
+                    _throw(_("Cannot connect input ports"));
                 }
             }
         } else {
@@ -321,11 +322,11 @@ int lingot_audio_jack_start(LingotAudioHandler* audio) {
                 snprintf(buff, sizeof(buff),
                          _("Cannot connect to requested port '%s'"),
                          audio->device);
-                throw(buff);
+                _throw(buff);
             }
         }
-    }catch {
-        lingot_msg_add_error(exception);
+    } _catch {
+        lingot_msg_add_error(_exception);
         result = -1;
 
         lingot_audio_jack_stop(audio);

--- a/src/lingot-audio-jack.h
+++ b/src/lingot-audio-jack.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,13 +29,21 @@
 
 #include <jack/jack.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     jack_port_t *input_port;
     jack_client_t *client;
     jack_nframes_t nframes;
-} LingotAudioHandlerExtraJack;
+} lingot_audio_handler_jack_t;
 
 int lingot_audio_jack_register(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 #endif

--- a/src/lingot-audio-oss.h
+++ b/src/lingot-audio-oss.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -27,11 +27,19 @@
 #ifndef LINGOT_AUDIO_OSS_H
 #define LINGOT_AUDIO_OSS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     int dsp; // file handler.
-} LingotAudioHandlerExtraOSS;
+} lingot_audio_handler_oss_t;
 
 int lingot_audio_oss_register(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 #endif

--- a/src/lingot-audio-pulseaudio.h
+++ b/src/lingot-audio-pulseaudio.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,11 +29,20 @@
 
 #include <pulse/simple.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
-    pa_simple *pa_client;
-} LingotAudioHandlerExtraPA;
+    pa_simple *client;
+    pa_sample_spec sample_spec;
+} lingot_audio_handler_pulseaudio_t;
 
 int lingot_audio_pulseaudio_register(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 #endif

--- a/src/lingot-audio.c
+++ b/src/lingot-audio.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
  *
  * This file is part of lingot.
@@ -46,10 +46,10 @@ typedef struct {
     lingot_audio_cancel_t func_cancel;
     lingot_audio_read_t func_read;
     lingot_audio_get_audio_system_properties_t func_system_properties;
-} LingotAudioSystemConnector;
+} lingot_audio_system_connector_t;
 
 static int audio_system_counter = 0;
-static LingotAudioSystemConnector audio_systems[10];
+static lingot_audio_system_connector_t audio_systems[10];
 
 int lingot_audio_system_register(const char* audio_system_name,
                                  lingot_audio_new_t func_new,
@@ -62,10 +62,10 @@ int lingot_audio_system_register(const char* audio_system_name,
 
     // printf("Found audio plugin '%s'\n", audio_system_name);
 
-    if ((size_t) (audio_system_counter + 1) >= sizeof(audio_systems)/sizeof (LingotAudioSystemConnector)) {
+    if ((size_t) (audio_system_counter + 1) >= sizeof(audio_systems)/sizeof (lingot_audio_system_connector_t)) {
         return -1;
     }
-    LingotAudioSystemConnector funcs;
+    lingot_audio_system_connector_t funcs;
     //    funcs.audio_system_index = audio_system_counter;
     funcs.audio_system_name = audio_system_name;
     funcs.func_new = func_new;
@@ -79,7 +79,7 @@ int lingot_audio_system_register(const char* audio_system_name,
     return audio_system_counter++;
 }
 
-static LingotAudioSystemConnector* lingot_audio_system_get(int audio_system_index) {
+static lingot_audio_system_connector_t* lingot_audio_system_get(int audio_system_index) {
     return ((audio_system_index >= 0) && (audio_system_index < audio_system_counter)) ?
                 &audio_systems[audio_system_index] : NULL;
 }
@@ -97,7 +97,7 @@ int lingot_audio_system_find_by_name(const char *audio_system_name)
 }
 
 const char* lingot_audio_system_get_name(int index) {
-    const LingotAudioSystemConnector* system = lingot_audio_system_get(index);
+    const lingot_audio_system_connector_t* system = lingot_audio_system_get(index);
     return system ? system->audio_system_name : NULL;
 }
 
@@ -105,15 +105,15 @@ int lingot_audio_system_get_count(void) {
     return audio_system_counter;
 }
 
-void lingot_audio_new(LingotAudioHandler* result,
+void lingot_audio_new(lingot_audio_handler_t* result,
                       int audio_system_index,
                       const char* device,
                       int sample_rate,
-                      LingotAudioProcessCallback process_callback,
+                      lingot_audio_process_callback_t process_callback,
                       void *process_callback_arg) {
 
     result->audio_system = audio_system_index;
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio_system_index);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio_system_index);
     if (system && system->func_new) {
         system->func_new(result, device, sample_rate);
 
@@ -131,9 +131,9 @@ void lingot_audio_new(LingotAudioHandler* result,
     }
 }
 
-void lingot_audio_destroy(LingotAudioHandler* audio) {
+void lingot_audio_destroy(lingot_audio_handler_t* audio) {
 
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio->audio_system);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio->audio_system);
     if (system && system->func_destroy) {
         system->func_destroy(audio);
     }
@@ -143,10 +143,10 @@ void lingot_audio_destroy(LingotAudioHandler* audio) {
     audio->audio_system = -1;
 }
 
-int lingot_audio_read(LingotAudioHandler* audio) {
+int lingot_audio_read(lingot_audio_handler_t* audio) {
     int samples_read = -1;
 
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio->audio_system);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio->audio_system);
     if (system && system->func_read) {
         samples_read = system->func_read(audio);
 
@@ -192,10 +192,10 @@ int lingot_audio_read(LingotAudioHandler* audio) {
     return samples_read;
 }
 
-int lingot_audio_system_get_properties(LingotAudioSystemProperties* properties,
+int lingot_audio_system_get_properties(lingot_audio_system_properties_t* properties,
                                        int audio_system_index) {
 
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio_system_index);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio_system_index);
     if (system && system->func_system_properties) {
         return system->func_system_properties(properties);
     }
@@ -203,8 +203,7 @@ int lingot_audio_system_get_properties(LingotAudioSystemProperties* properties,
     return -1;
 }
 
-void lingot_audio_system_properties_destroy(
-        LingotAudioSystemProperties* properties) {
+void lingot_audio_system_properties_destroy(lingot_audio_system_properties_t* properties) {
 
     int i;
     if (properties->devices) {
@@ -214,15 +213,17 @@ void lingot_audio_system_properties_destroy(
             }
         }
         free(properties->devices);
+        properties->devices = NULL;
     }
 }
 
 void* lingot_audio_mainloop(void* _audio) {
 
     int samples_read = 0;
-    LingotAudioHandler* audio = _audio;
+    lingot_audio_handler_t* audio = _audio;
 
     while (audio->running) {
+
         // blocking read
         samples_read = lingot_audio_read(audio);
 
@@ -244,16 +245,18 @@ void* lingot_audio_mainloop(void* _audio) {
     return NULL;
 }
 
-int lingot_audio_start(LingotAudioHandler* audio) {
+int lingot_audio_start(lingot_audio_handler_t* audio) {
 
     int result = -1;
 
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio->audio_system);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio->audio_system);
     if (system) {
         if (system->func_start) {
             result = system->func_start(audio);
         } else {
             pthread_attr_init(&audio->thread_input_read_attr);
+
+            audio->running = 1;
 
             // detached thread.
             //  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
@@ -267,25 +270,21 @@ int lingot_audio_start(LingotAudioHandler* audio) {
         }
     }
 
-    if (result == 0) {
-        audio->running = 1;
-    }
-
     return result;
 }
 
 // function invoked when the audio thread must be cancelled
-void lingot_audio_cancel(LingotAudioHandler* audio) {
+void lingot_audio_cancel(lingot_audio_handler_t* audio) {
     // TODO: avoid
     fprintf(stderr, "warning: canceling audio thread\n");
 
-    LingotAudioSystemConnector* system = lingot_audio_system_get(audio->audio_system);
+    lingot_audio_system_connector_t* system = lingot_audio_system_get(audio->audio_system);
     if (system && system->func_cancel) {
         system->func_cancel(audio);
     }
 }
 
-void lingot_audio_stop(LingotAudioHandler* audio) {
+void lingot_audio_stop(lingot_audio_handler_t* audio) {
     void* thread_result;
 
     int result;
@@ -294,9 +293,9 @@ void lingot_audio_stop(LingotAudioHandler* audio) {
 
     gettimeofday(&tout_abs, NULL );
 
-    if (audio->running == 1) {
+    if (audio->running) {
         audio->running = 0;
-        LingotAudioSystemConnector* system = lingot_audio_system_get(audio->audio_system);
+        lingot_audio_system_connector_t* system = lingot_audio_system_get(audio->audio_system);
         if (system) {
             if (system->func_stop) {
                 system->func_stop(audio);

--- a/src/lingot-audio.h
+++ b/src/lingot-audio.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -25,29 +25,33 @@
 #ifndef LINGOT_AUDIO_H
 #define LINGOT_AUDIO_H
 
-#include "lingot-config.h"
-
 #include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lingot-config.h"
 
 #define FLT_SAMPLE_SCALE	32767.0
 
 // for audio systems that are self-driven (e.g. Jack), we need a callback function (and signature)
 // to process the audio
-typedef void (*LingotAudioProcessCallback)(FLT* read_buffer,
-                                           unsigned int read_buffer_size_samples, void *arg);
+typedef void (*lingot_audio_process_callback_t)(double* read_buffer,
+                                                unsigned int read_buffer_size_samples, void *arg);
 
 typedef struct {
 
     int audio_system;
     char device[256];
 
-    LingotAudioProcessCallback process_callback;
+    lingot_audio_process_callback_t process_callback;
     void* process_callback_arg;
 
     void* audio_handler_extra;
 
     unsigned int read_buffer_size_samples;
-    FLT* flt_read_buffer;
+    double* flt_read_buffer;
 
     unsigned int real_sample_rate;
 
@@ -65,7 +69,7 @@ typedef struct {
     // indicates whether the thread was interrupted (by the audio server, not
     // by the user)
     int interrupted;
-} LingotAudioHandler;
+} lingot_audio_handler_t;
 
 typedef struct {
 
@@ -76,17 +80,17 @@ typedef struct {
 
     int n_devices; // number of available devices
     const char** devices; // devices
-} LingotAudioSystemProperties;
+} lingot_audio_system_properties_t;
 
 
 // set of callbacks that define the interaction with an audio system.
-typedef void (*lingot_audio_new_t) (LingotAudioHandler* audio, const char* device, int sample_rate);
-typedef void (*lingot_audio_destroy_t) (LingotAudioHandler* audio);
-typedef int  (*lingot_audio_start_t) (LingotAudioHandler* audio);
-typedef void (*lingot_audio_stop_t) (LingotAudioHandler* audio);
-typedef void (*lingot_audio_cancel_t) (LingotAudioHandler* audio);
-typedef int  (*lingot_audio_read_t) (LingotAudioHandler* audio);
-typedef int  (*lingot_audio_get_audio_system_properties_t) (LingotAudioSystemProperties* properties);
+typedef void (*lingot_audio_new_t) (lingot_audio_handler_t* audio, const char* device, int sample_rate);
+typedef void (*lingot_audio_destroy_t) (lingot_audio_handler_t* audio);
+typedef int  (*lingot_audio_start_t) (lingot_audio_handler_t* audio);
+typedef void (*lingot_audio_stop_t) (lingot_audio_handler_t* audio);
+typedef void (*lingot_audio_cancel_t) (lingot_audio_handler_t* audio);
+typedef int  (*lingot_audio_read_t) (lingot_audio_handler_t* audio);
+typedef int  (*lingot_audio_get_audio_system_properties_t) (lingot_audio_system_properties_t* properties);
 
 // registers an audio system
 int lingot_audio_system_register(const char* audio_system_name,
@@ -100,27 +104,31 @@ int lingot_audio_system_register(const char* audio_system_name,
 int lingot_audio_system_find_by_name(const char* audio_system_name);
 const char* lingot_audio_system_get_name(int index);
 int lingot_audio_system_get_count(void);
-int lingot_audio_system_get_properties(LingotAudioSystemProperties*,
+int lingot_audio_system_get_properties(lingot_audio_system_properties_t*,
                                        int audio_system_index);
 // Return status : 0 for OK, else -1.
 
-void lingot_audio_system_properties_destroy(LingotAudioSystemProperties*);
+void lingot_audio_system_properties_destroy(lingot_audio_system_properties_t*);
 
 // creates an audio handler
-void lingot_audio_new(LingotAudioHandler*,
+void lingot_audio_new(lingot_audio_handler_t*,
                       int audio_system_index,
                       const char* device,
                       int sample_rate,
-                      LingotAudioProcessCallback process_callback,
+                      lingot_audio_process_callback_t process_callback,
                       void *process_callback_arg);
 // In case of failure, audio_system is set to -1 in the LingotAudioHandler struct.
 
 // destroys an audio handler
-void lingot_audio_destroy(LingotAudioHandler*);
+void lingot_audio_destroy(lingot_audio_handler_t*);
 
 void* lingot_audio_mainloop(void*);
 
-int lingot_audio_start(LingotAudioHandler*);
-void lingot_audio_stop(LingotAudioHandler*);
+int lingot_audio_start(lingot_audio_handler_t*);
+void lingot_audio_stop(lingot_audio_handler_t*);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/lingot-complex.c
+++ b/src/lingot-complex.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -24,34 +24,34 @@
 
 #include "lingot-complex.h"
 
-void lingot_complex_add(const LingotComplex a, const LingotComplex b, LingotComplex c) {
+void lingot_complex_add(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c) {
     c[0] = a[0] + b[0];
     c[1] = a[1] + b[1];
 }
 
-void lingot_complex_sub(const LingotComplex a, const LingotComplex b, LingotComplex c) {
+void lingot_complex_sub(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c) {
     c[0] = a[0] - b[0];
     c[1] = a[1] - b[1];
 }
 
-void lingot_complex_mul(const LingotComplex a, const LingotComplex b, LingotComplex c) {
+void lingot_complex_mul(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c) {
     c[0] = a[0] * b[0] - a[1] * b[1];
     c[1] = a[1] * b[0] + a[0] * b[1];
 }
 
-void lingot_complex_div(const LingotComplex a, const LingotComplex b, LingotComplex c) {
+void lingot_complex_div(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c) {
     FLT bm2 = b[0] * b[0] + b[1] * b[1];
     c[0] = (a[0] * b[0] + a[1] * b[1]) / bm2;
     c[1] = (a[1] * b[0] - a[0] * b[1]) / bm2;
 }
 
-void lingot_complex_mul_by(LingotComplex a, const LingotComplex b) {
+void lingot_complex_mul_by(lingot_complex_t a, const lingot_complex_t b) {
     double rr = a[0] * b[0] - a[1] * b[1];
     a[1] = a[1] * b[0] + a[0] * b[1];
     a[0] = rr;
 }
 
-void lingot_complex_div_by(LingotComplex a, const LingotComplex b) {
+void lingot_complex_div_by(lingot_complex_t a, const lingot_complex_t b) {
     FLT bm2 = b[0] * b[0] + b[1] * b[1];
     double rr = (a[0] * b[0] + a[1] * b[1]) / bm2;
     a[1] = (a[1] * b[0] - a[0] * b[1]) / bm2;

--- a/src/lingot-complex.h
+++ b/src/lingot-complex.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -30,36 +30,36 @@
 
 // single ... complex arithmetic  :)
 
-typedef FLT LingotComplex[2];
+typedef FLT lingot_complex_t[2];
 
 /**
  * Addition. All parameters can overlap.
  */
-void lingot_complex_add(const LingotComplex a, const LingotComplex b, LingotComplex c);
+void lingot_complex_add(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c);
 
 /**
  * Subtraction. All parameters can overlap.
  */
-void lingot_complex_sub(const LingotComplex a, const LingotComplex b, LingotComplex c);
+void lingot_complex_sub(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c);
 
 /**
  * Multiplication. Parameters cannot overlap.
  */
-void lingot_complex_mul(const LingotComplex a, const LingotComplex b, LingotComplex c);
+void lingot_complex_mul(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c);
 
 /**
  * Division. Parameters cannot overlap.
  */
-void lingot_complex_div(const LingotComplex a, const LingotComplex b, LingotComplex c);
+void lingot_complex_div(const lingot_complex_t a, const lingot_complex_t b, lingot_complex_t c);
 
 /**
  * Computes a *= b
  */
-void lingot_complex_mul_by(LingotComplex a, const LingotComplex b);
+void lingot_complex_mul_by(lingot_complex_t a, const lingot_complex_t b);
 
 /**
  * Computes a /= b
  */
-void lingot_complex_div_by(LingotComplex a, const LingotComplex b);
+void lingot_complex_div_by(lingot_complex_t a, const lingot_complex_t b);
 
 #endif

--- a/src/lingot-config-scale.c
+++ b/src/lingot-config-scale.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -30,8 +30,9 @@
 #include "lingot-config-scale.h"
 #include "lingot-i18n.h"
 #include "lingot-msg.h"
+#include "lingot-defs.h"
 
-void lingot_config_scale_new(LingotScale* scale) {
+void lingot_config_scale_new(lingot_scale_t* scale) {
 
     scale->name = NULL;
     scale->notes = 0;
@@ -42,7 +43,7 @@ void lingot_config_scale_new(LingotScale* scale) {
     scale->base_frequency = 0.0;
 }
 
-void lingot_config_scale_allocate(LingotScale* scale, unsigned short int notes) {
+void lingot_config_scale_allocate(lingot_scale_t* scale, unsigned short int notes) {
     scale->notes = notes;
     scale->note_name = malloc(notes * sizeof(char*));
     unsigned int i = 0;
@@ -54,7 +55,7 @@ void lingot_config_scale_allocate(LingotScale* scale, unsigned short int notes) 
     scale->offset_ratios[1] = malloc(notes * sizeof(short int));
 }
 
-void lingot_config_scale_destroy(LingotScale* scale) {
+void lingot_config_scale_destroy(lingot_scale_t* scale) {
     unsigned short int i;
 
     for (i = 0; i < scale->notes; i++) {
@@ -70,7 +71,7 @@ void lingot_config_scale_destroy(LingotScale* scale) {
     lingot_config_scale_new(scale);
 }
 
-void lingot_config_scale_restore_default_values(LingotScale* scale) {
+void lingot_config_scale_restore_default_values(lingot_scale_t* scale) {
 
     unsigned short int i;
     const char* tone_string[] = {
@@ -99,7 +100,7 @@ void lingot_config_scale_restore_default_values(LingotScale* scale) {
     }
 }
 
-void lingot_config_scale_copy(LingotScale* dst, const LingotScale* src) {
+void lingot_config_scale_copy(lingot_scale_t* dst, const lingot_scale_t* src) {
     unsigned short int i;
 
     lingot_config_scale_destroy(dst);
@@ -117,30 +118,30 @@ void lingot_config_scale_copy(LingotScale* dst, const LingotScale* src) {
     }
 }
 
-int lingot_config_scale_get_octave(const LingotScale* scale, int index) {
+int lingot_config_scale_get_octave(const lingot_scale_t* scale, int index) {
     return (index < 0) ?
                 ((index + 1) / scale->notes) - 1 :
                 index / scale->notes;
 }
 
-int lingot_config_scale_get_note_index(const LingotScale* scale, int index) {
+int lingot_config_scale_get_note_index(const lingot_scale_t* scale, int index) {
     int r = index % scale->notes;
     return r < 0 ? r + scale->notes : r;
 }
 
-FLT lingot_config_scale_get_absolute_offset(const LingotScale* scale, int index) {
+FLT lingot_config_scale_get_absolute_offset(const lingot_scale_t* scale, int index) {
     return lingot_config_scale_get_octave(scale, index) * 1200.0
             + scale->offset_cents[lingot_config_scale_get_note_index(scale, index)];
 }
 
-FLT lingot_config_scale_get_frequency(const LingotScale* scale, int index) {
+FLT lingot_config_scale_get_frequency(const lingot_scale_t* scale, int index) {
     return scale->base_frequency
             * pow(2.0,
                   lingot_config_scale_get_absolute_offset(scale, index)
                   / 1200.0);
 }
 
-int lingot_config_scale_get_closest_note_index(const LingotScale* scale,
+int lingot_config_scale_get_closest_note_index(const lingot_scale_t* scale,
                                                FLT freq, FLT deviation, FLT* error_cents) {
 
     int note_index = 0;

--- a/src/lingot-config-scale.h
+++ b/src/lingot-config-scale.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -25,42 +25,50 @@
 #ifndef LINGOT_CONFIG_SCALE_H
 #define LINGOT_CONFIG_SCALE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-defs.h"
 
 typedef struct {
     char* name; 					// name of the scale
     unsigned short int notes; 		// number of notes
-    FLT* offset_cents; 				// offset in cents
+    FLT* offset_cents;           // offset in cents
     short int* offset_ratios[2]; 	// offset in ratios (pairs of integers)
     FLT base_frequency; 			// frequency of the first note (tipically C4)
     char** note_name; 				// note names
-} LingotScale;
+} lingot_scale_t;
 
-void lingot_config_scale_new(LingotScale*);
-void lingot_config_scale_allocate(LingotScale* scale, unsigned short int notes);
-void lingot_config_scale_destroy(LingotScale* scale);
+void lingot_config_scale_new(lingot_scale_t*);
+void lingot_config_scale_allocate(lingot_scale_t* scale, unsigned short int notes);
+void lingot_config_scale_destroy(lingot_scale_t* scale);
 
-void lingot_config_scale_copy(LingotScale* dst, const LingotScale* src);
+void lingot_config_scale_copy(lingot_scale_t* dst, const lingot_scale_t* src);
 /* The dst argument *must* be initialized with _new. */
 
-void lingot_config_scale_restore_default_values(LingotScale* scale);
+void lingot_config_scale_restore_default_values(lingot_scale_t* scale);
 
 // Gets the note index within the range [0, num notes)
-int lingot_config_scale_get_note_index(const LingotScale* scale, int index);
+int lingot_config_scale_get_note_index(const lingot_scale_t* scale, int index);
 
 // Gets an octave number from the note index
 // Octave 0 starts at index 0
-int lingot_config_scale_get_octave(const LingotScale* scale, int index);
+int lingot_config_scale_get_octave(const lingot_scale_t* scale, int index);
 
 // Gets the frequency of a given note in the scale.
 // The final absolute frequency depends on the base_frequency configured for
 // the scale, which corresponds to note index 0.
 // Tipically, the base frequency is C4, so in order to get C1 in a 12-note scale,
 // we need to pass -36 here as note index
-FLT lingot_config_scale_get_frequency(const LingotScale* scale, int index);
+double lingot_config_scale_get_frequency(const lingot_scale_t* scale, int index);
 
 
-int lingot_config_scale_get_closest_note_index(const LingotScale* scale,
-                                               FLT freq, FLT deviation, FLT* error_cents);
+int lingot_config_scale_get_closest_note_index(const lingot_scale_t* scale,
+                                               double freq, double deviation, double* error_cents);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LINGOT_CONFIG_SCALE_H */

--- a/src/lingot-config.c
+++ b/src/lingot-config.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -36,19 +36,26 @@
 #include "lingot-i18n.h"
 #include "lingot-audio.h"
 
-void lingot_config_new(LingotConfig* config) {
+void lingot_config_new(lingot_config_t* config) {
 
     config->max_nr_iter = 10; // iterations
     config->window_type = HAMMING;
     config->optimize_internal_parameters = 0;
+
+    config->audio_system_index = -1;
+    int i;
+    for (i = 0; i < (int) (sizeof(config->audio_dev)/sizeof(config->audio_dev[0])); ++i) {
+        sprintf(config->audio_dev[i], "%s", "");
+    }
+
     lingot_config_scale_new(&config->scale);
 }
 
-void lingot_config_destroy(LingotConfig* config) {
+void lingot_config_destroy(lingot_config_t* config) {
     lingot_config_scale_destroy(&config->scale);
 }
 
-void lingot_config_copy(LingotConfig* dst, const LingotConfig* src) {
+void lingot_config_copy(lingot_config_t* dst, const lingot_config_t* src) {
     *dst = *src;
     lingot_config_scale_new(&dst->scale); // null scale that will be destroyed in the copy below
     lingot_config_scale_copy(&dst->scale, &src->scale);
@@ -56,7 +63,7 @@ void lingot_config_copy(LingotConfig* dst, const LingotConfig* src) {
 
 //----------------------------------------------------------------------------
 
-void lingot_config_restore_default_values(LingotConfig* config) {
+void lingot_config_restore_default_values(lingot_config_t* config) {
 
     config->audio_system_index = lingot_audio_system_find_by_name("ALSA");
     if (config->audio_system_index < 0) {
@@ -101,7 +108,7 @@ void lingot_config_restore_default_values(LingotConfig* config) {
 
 //----------------------------------------------------------------------------
 
-void lingot_config_update_internal_params(LingotConfig* config) {
+void lingot_config_update_internal_params(lingot_config_t* config) {
 
     // derived parameters.
 

--- a/src/lingot-config.h
+++ b/src/lingot-config.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -24,6 +24,10 @@
 
 #ifndef LINGOT_CONFIG_H
 #define LINGOT_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "lingot-defs.h"
 #include "lingot-config-scale.h"
@@ -93,19 +97,23 @@ typedef struct {
 
     //----------------------------------------------------------------------------
 
-    LingotScale scale;
+    lingot_scale_t scale;
 
-} LingotConfig;
+} lingot_config_t;
 
 
-void lingot_config_new(LingotConfig*);
-void lingot_config_destroy(LingotConfig*);
-void lingot_config_copy(LingotConfig* dst, const LingotConfig* src);
+void lingot_config_new(lingot_config_t*);
+void lingot_config_destroy(lingot_config_t*);
+void lingot_config_copy(lingot_config_t* dst, const lingot_config_t* src);
 
 // back to default configuration.
-void lingot_config_restore_default_values(LingotConfig*);
+void lingot_config_restore_default_values(lingot_config_t*);
 
 // derivate internal parameters from external ones.
-void lingot_config_update_internal_params(LingotConfig*);
+void lingot_config_update_internal_params(lingot_config_t*);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LINGOT_CONFIG_H

--- a/src/lingot-core.h
+++ b/src/lingot-core.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -27,41 +27,51 @@
 
 #include <pthread.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-defs.h"
-#include "lingot-complex.h"
-#include "lingot-filter.h"
 #include "lingot-config.h"
 
-#include "lingot-audio.h"
-
-#include "lingot-fft.h"
-
 typedef struct {
-    void *private;
-} LingotCore;
+    void *core_private;
+} lingot_core_t;
 
 //----------------------------------------------------------------
 
-void lingot_core_new(LingotCore*, LingotConfig*);
-void lingot_core_destroy(LingotCore*);
+void lingot_core_new(lingot_core_t*, lingot_config_t*);
+void lingot_core_destroy(lingot_core_t*);
 
 // runs the core mainloop
-void lingot_core_mainloop(LingotCore* core);
+void lingot_core_mainloop(lingot_core_t* core);
+
+void lingot_core_compute_fundamental_fequency(lingot_core_t* core);
+
+// starts the core in the calling thread (starts the audio thread)
+void lingot_core_start(lingot_core_t*);
+
+// stops the core (audio thread)
+void lingot_core_stop(lingot_core_t*);
 
 // starts the core in another thread
-void lingot_core_thread_start(LingotCore*);
+void lingot_core_thread_start(lingot_core_t*);
 
 // stops the core started in another thread
-void lingot_core_thread_stop(LingotCore*);
+void lingot_core_thread_stop(lingot_core_t*);
 
 // Thread-safe request if the core is running
-int lingot_core_thread_is_running(LingotCore*);
+int lingot_core_thread_is_running(const lingot_core_t*);
 
 // Thread-safe request to the latest computed frequency
-FLT lingot_core_thread_get_result_frequency(LingotCore*);
+FLT lingot_core_thread_get_result_frequency(lingot_core_t*);
 
 // Thread-safe access to the latest computed spectrum. The SPD is copied into
 // an internal secondary buffer that can be accessed afterwards from the calling thread
-FLT* lingot_core_thread_get_result_spd(LingotCore*);
+FLT* lingot_core_thread_get_result_spd(lingot_core_t*);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //LINGOT_CORE_H

--- a/src/lingot-defs.h
+++ b/src/lingot-defs.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -28,10 +28,10 @@
 #include "../config.h"
 
 // floating point precision.
-#define FLT                  double
+#define FLT                         double
 
-#define CONFIG_DIR_NAME           ".config/lingot/"
-#define DEFAULT_CONFIG_FILE_NAME  "lingot.conf"
+#define CONFIG_DIR_NAME             ".config/lingot/"
+#define DEFAULT_CONFIG_FILE_NAME    "lingot.conf"
 extern char CONFIG_FILE_NAME[];
 
 #define QUICK_MESSAGES
@@ -43,14 +43,11 @@ extern char CONFIG_FILE_NAME[];
 #define MID_A_FREQUENCY		440.0
 #define MID_C_FREQUENCY		261.625565
 
-/* object forward declaration */
-typedef struct _LingotMainFrame LingotMainFrame;
-
 // simple try-catch simulation, do not use throw inside loops nor nest try-catch
 // blocks
-#define try exception = 0; do
-#define throw(a) {exception = a;break;}
-#define catch while (0); if (exception != 0)
+#define _try _exception = 0; do
+#define _throw(a) { _exception = a;break; }
+#define _catch while (0); if (_exception != 0)
 
 #ifndef M_PI
 #    define M_PI 3.14159265358979323846
@@ -58,8 +55,8 @@ typedef struct _LingotMainFrame LingotMainFrame;
 
 // this option allows us to throw exception from loops, it contains a goto
 // statement, but totally controlled. It fails when trying to indent code.
-//#define try exception = 0;do
-//#define throw(a) {exception = a;goto catch_label;}
-//#define catch while (0);catch_label: if (exception != 0)
+//#define _try _exception = 0;do
+//#define _throw(a) {_exception = a;goto catch_label;}
+//#define _catch while (0);catch_label: if (_exception != 0)
 
 #endif

--- a/src/lingot-fft.c
+++ b/src/lingot-fft.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -37,7 +37,7 @@
  DTFT functions.
  */
 
-void lingot_fft_plan_create(LingotFFTPlan* result, FLT* in, unsigned int n) {
+void lingot_fft_plan_create(lingot_fft_plan_t* result, FLT* in, unsigned int n) {
 
     result->n = n;
     result->in = in;
@@ -50,7 +50,7 @@ void lingot_fft_plan_create(LingotFFTPlan* result, FLT* in, unsigned int n) {
     FLT alpha;
 
     // twiddle factors
-    result->wn = (LingotComplex*) malloc((n >> 1) * sizeof(LingotComplex));
+    result->wn = (lingot_complex_t*) malloc((n >> 1) * sizeof(lingot_complex_t));
 
     unsigned int i;
     for (i = 0; i < (n >> 1); i++) {
@@ -58,13 +58,13 @@ void lingot_fft_plan_create(LingotFFTPlan* result, FLT* in, unsigned int n) {
         result->wn[i][0] = cos(alpha);
         result->wn[i][1] = sin(alpha);
     }
-    result->fft_out = malloc(n * sizeof(LingotComplex)); // complex signal in freq domain.
-    memset(result->fft_out, 0, n * sizeof(LingotComplex));
+    result->fft_out = malloc(n * sizeof(lingot_complex_t)); // complex signal in freq domain.
+    memset(result->fft_out, 0, n * sizeof(lingot_complex_t));
 #endif
 
 }
 
-void lingot_fft_plan_destroy(LingotFFTPlan* plan) {
+void lingot_fft_plan_destroy(lingot_fft_plan_t* plan) {
 
 #ifdef LIBFFTW
     fftw_destroy_plan(plan->fftwplan);
@@ -72,14 +72,16 @@ void lingot_fft_plan_destroy(LingotFFTPlan* plan) {
 #else
     free(plan->fft_out);
     free(plan->wn);
+    plan->fft_out = NULL;
+    plan->wn = NULL;
 #endif
 }
 
 #ifndef LIBFFTW
 
-void _lingot_fft_fft(FLT* in, LingotComplex* out, LingotComplex* wn, unsigned long int N,
+void _lingot_fft_fft(FLT* in, lingot_complex_t* out, lingot_complex_t* wn, unsigned long int N,
                      unsigned long int offset, unsigned long int d1, unsigned long int step) {
-    LingotComplex X1, X2;
+    lingot_complex_t X1, X2;
     unsigned long int Np2 = (N >> 1); // N/2
     unsigned long int a, b, c, q;
 
@@ -112,13 +114,13 @@ void _lingot_fft_fft(FLT* in, LingotComplex* out, LingotComplex* wn, unsigned lo
     }
 }
 
-void lingot_fft_fft(LingotFFTPlan* plan) {
+void lingot_fft_fft(lingot_fft_plan_t* plan) {
     _lingot_fft_fft(plan->in, plan->fft_out, plan->wn, plan->n, 0, 0, 1);
 }
 
 #endif
 
-void lingot_fft_compute_dft_and_spd(LingotFFTPlan* plan, FLT* out, unsigned int n_out) {
+void lingot_fft_compute_dft_and_spd(lingot_fft_plan_t* plan, FLT* out, unsigned int n_out) {
 
     unsigned int i;
     double _1_N2 = 1.0 / (plan->n * plan->n);

--- a/src/lingot-fft.h
+++ b/src/lingot-fft.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,13 +29,12 @@
  Fourier transforms.
  */
 
-#include "lingot-defs.h"
-
 #ifdef LIBFFTW
 # include <fftw3.h>
 #endif
 
-# include "lingot-complex.h"
+#include "lingot-defs.h"
+#include "lingot-complex.h"
 
 typedef struct {
 
@@ -46,16 +45,16 @@ typedef struct {
     fftw_plan fftwplan;
 #else
     // phase factor table, for FFT optimization.
-    LingotComplex* wn;
+    lingot_complex_t* wn;
 #endif
-    LingotComplex* fft_out; // complex signal in freq.
-} LingotFFTPlan;
+    lingot_complex_t* fft_out; // complex signal in freq.
+} lingot_fft_plan_t;
 
-void lingot_fft_plan_create(LingotFFTPlan*, FLT* in, unsigned int n);
-void lingot_fft_plan_destroy(LingotFFTPlan*);
+void lingot_fft_plan_create(lingot_fft_plan_t*, FLT* in, unsigned int n);
+void lingot_fft_plan_destroy(lingot_fft_plan_t*);
 
 // Full Spectral Power Distribution (SPD) esteem.
-void lingot_fft_compute_dft_and_spd(LingotFFTPlan*, FLT* out, unsigned int n_out);
+void lingot_fft_compute_dft_and_spd(lingot_fft_plan_t*, FLT* out, unsigned int n_out);
 
 // Spectral Power Distribution (SPD) evaluation at a given frequency.
 void lingot_fft_spd_eval(FLT* in, unsigned int N1, FLT wi, FLT dw, FLT* out, unsigned int N2);

--- a/src/lingot-filter.c
+++ b/src/lingot-filter.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -31,7 +31,7 @@
 #define max(a,b) (((a)<(b))?(b):(a))
 
 // given each polynomial order and coefs, with optional initial status.
-void lingot_filter_new(LingotFilter* filter,
+void lingot_filter_new(lingot_filter_t* filter,
                        unsigned int Na, unsigned int Nb,
                        const FLT* a, const FLT* b) {
     unsigned int i;
@@ -56,21 +56,24 @@ void lingot_filter_new(LingotFilter* filter,
     }
 }
 
-void lingot_filter_reset(LingotFilter* filter) {
+void lingot_filter_reset(lingot_filter_t* filter) {
     unsigned int i;
     for (i = 0; i <= filter->N; i++) {
         filter->s[i] = 0.0;
     }
 }
 
-void lingot_filter_destroy(LingotFilter* filter) {
+void lingot_filter_destroy(lingot_filter_t* filter) {
     free(filter->a);
     free(filter->b);
     free(filter->s);
+    filter->a = NULL;
+    filter->b = NULL;
+    filter->s = NULL;
 }
 
 // Digital Filter Implementation II, in & out can overlap.
-void lingot_filter_filter(LingotFilter* filter, unsigned int n,
+void lingot_filter_filter(lingot_filter_t* filter, unsigned int n,
                           const FLT* in, FLT* out) {
     FLT w, y;
     unsigned int i;
@@ -95,7 +98,7 @@ void lingot_filter_filter(LingotFilter* filter, unsigned int n,
 }
 
 // single sample filtering
-FLT lingot_filter_filter_sample(LingotFilter* filter, FLT in) {
+FLT lingot_filter_filter_sample(lingot_filter_t* filter, FLT in) {
     FLT result;
 
     lingot_filter_filter(filter, 1, &in, &result);
@@ -103,9 +106,9 @@ FLT lingot_filter_filter_sample(LingotFilter* filter, FLT in) {
 }
 
 // vector prod
-void lingot_filter_vector_product(unsigned int n, LingotComplex* vector, LingotComplex result) {
+void lingot_filter_vector_product(unsigned int n, lingot_complex_t* vector, lingot_complex_t result) {
     unsigned int i;
-    LingotComplex aux1;
+    lingot_complex_t aux1;
 
     result[0] = 1.0;
     result[1] = 0.0;
@@ -119,7 +122,7 @@ void lingot_filter_vector_product(unsigned int n, LingotComplex* vector, LingotC
 }
 
 // Chebyshev filters
-void lingot_filter_cheby_design(LingotFilter* filter, unsigned int n, FLT Rp, FLT wc) {
+void lingot_filter_cheby_design(lingot_filter_t* filter, unsigned int n, FLT Rp, FLT wc) {
     unsigned int i; // loops
     unsigned int k;
     unsigned int p;
@@ -131,7 +134,7 @@ void lingot_filter_cheby_design(LingotFilter* filter, unsigned int n, FLT Rp, FL
     FLT new_b[n + 1];
 
     // locate poles
-    LingotComplex pole[n];
+    lingot_complex_t pole[n];
 
     for (i = 0; i < n; i++) {
         pole[i][0] = 0.0;
@@ -156,7 +159,7 @@ void lingot_filter_cheby_design(LingotFilter* filter, unsigned int n, FLT Rp, FL
         pole[k][1] = cv0 * sin(t);
     }
 
-    LingotComplex gain;
+    lingot_complex_t gain;
     lingot_filter_vector_product(n, pole, gain);
 
     if ((n & 1) == 0) { // even
@@ -175,15 +178,15 @@ void lingot_filter_cheby_design(LingotFilter* filter, unsigned int n, FLT Rp, FL
     }
 
     // bilinear transform
-    LingotComplex sp[n];
+    lingot_complex_t sp[n];
 
     for (i = 0; i < n; i++) {
         sp[i][0] = (2.0 - pole[i][0] * T) / T;
         sp[i][1] = (0.0 - pole[i][1] * T) / T;
     }
 
-    LingotComplex tmp1;
-    LingotComplex aux2;
+    lingot_complex_t tmp1;
+    lingot_complex_t aux2;
 
     lingot_filter_vector_product(n, sp, tmp1);
 

--- a/src/lingot-filter.h
+++ b/src/lingot-filter.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -28,6 +28,10 @@
 #include <fcntl.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-defs.h"
 
 /*
@@ -42,27 +46,31 @@ typedef struct {
 
     unsigned int N;
 
-} LingotFilter;
+} lingot_filter_t;
 
-void lingot_filter_new(LingotFilter*,
+void lingot_filter_new(lingot_filter_t*,
                        unsigned int Na, unsigned int Nb,
                        const FLT* a, const FLT* b);
 
-void lingot_filter_reset(LingotFilter* filter);
+void lingot_filter_reset(lingot_filter_t* filter);
 
 /**
  * Design a Chebyshev Type I low pass filter with Rp dB of pass band ripple
  * with cutoff pi*wc radians.
  */
-void lingot_filter_cheby_design(LingotFilter*, unsigned int order, FLT Rp, FLT wc);
+void lingot_filter_cheby_design(lingot_filter_t*, unsigned int order, FLT Rp, FLT wc);
 
-void lingot_filter_destroy(LingotFilter*);
+void lingot_filter_destroy(lingot_filter_t*);
 
 // Digital Filter Implementation II, in & out can overlap. Vector filtering
-void lingot_filter_filter(LingotFilter*, unsigned int n, const FLT* in,
+void lingot_filter_filter(lingot_filter_t*, unsigned int n, const FLT* in,
                           FLT* out);
 
 // sample filtering
-FLT lingot_filter_filter_sample(LingotFilter*, FLT in);
+FLT lingot_filter_filter_sample(lingot_filter_t*, FLT in);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/lingot-gauge.c
+++ b/src/lingot-gauge.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -24,7 +24,7 @@
 
 #include "lingot-gauge.h"
 
-void lingot_gauge_new(LingotGauge* gauge, FLT initial_position) {
+void lingot_gauge_new(lingot_gauge_t* gauge, FLT gauge_rate, FLT initial_position) {
 
     //
     // ----- ERROR GAUGE FILTER CONFIGURATION -----
@@ -64,18 +64,18 @@ void lingot_gauge_new(LingotGauge* gauge, FLT initial_position) {
     const FLT q = 6;
     // friction coefficient.
 
-    const FLT a[] = { k + GAUGE_RATE * (q + GAUGE_RATE), -GAUGE_RATE
-                      * (q + 2.0 * GAUGE_RATE), GAUGE_RATE * GAUGE_RATE };
+    const FLT a[] = { k + gauge_rate * (q + gauge_rate), -gauge_rate
+                      * (q + 2.0 * gauge_rate), gauge_rate * gauge_rate };
     const FLT b[] = { k };
 
     lingot_filter_new(&gauge->filter, 2, 0, a, b);
     lingot_gauge_compute(gauge, initial_position);
 }
 
-void lingot_gauge_destroy(LingotGauge* gauge) {
+void lingot_gauge_destroy(lingot_gauge_t* gauge) {
     lingot_filter_destroy(&gauge->filter);
 }
 
-void lingot_gauge_compute(LingotGauge* gauge, FLT sample) {
-    gauge->position = lingot_filter_filter_sample(&gauge->filter, sample);
+void lingot_gauge_compute(lingot_gauge_t* gauge, FLT position) {
+    gauge->position = lingot_filter_filter_sample(&gauge->filter, position);
 }

--- a/src/lingot-gauge.h
+++ b/src/lingot-gauge.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -25,6 +25,10 @@
 #ifndef LINGOT_GAUGE_H
 #define LINGOT_GAUGE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-defs.h"
 #include "lingot-filter.h"
 
@@ -33,12 +37,16 @@
  */
 
 typedef struct {
-    LingotFilter filter;
+    lingot_filter_t filter;
     FLT position;
-} LingotGauge;
+} lingot_gauge_t;
 
-void lingot_gauge_new(LingotGauge*, FLT);
-void lingot_gauge_destroy(LingotGauge*);
-void lingot_gauge_compute(LingotGauge*, FLT);
+void lingot_gauge_new(lingot_gauge_t*, FLT gauge_rate, FLT initial_position);
+void lingot_gauge_destroy(lingot_gauge_t*);
+void lingot_gauge_compute(lingot_gauge_t*, FLT position);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*LINGOT_GAUGE_H*/

--- a/src/lingot-gui-config-dialog-scale.h
+++ b/src/lingot-gui-config-dialog-scale.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,28 +29,28 @@
 
 #include "lingot-gui-config-dialog.h"
 
-struct LingotConfigDialog;
-struct LingotScale;
+struct lingot_config_dialog_t;
+struct lingot_scale_t;
 struct GtkBuilder;
 
 // initialize and show the components
-void lingot_gui_config_dialog_scale_show(LingotConfigDialog*, GtkBuilder*);
+void lingot_gui_config_dialog_scale_show(lingot_config_dialog_t*, GtkBuilder*);
 
 // validate the information stored in the table
-int lingot_gui_config_dialog_scale_validate(const LingotConfigDialog* dialog,
-                                            const LingotScale* scale);
+int lingot_gui_config_dialog_scale_validate(const lingot_config_dialog_t* dialog,
+                                            const lingot_scale_t* scale);
 
 // copies the information stores in the table to the internal data structure
-void lingot_gui_config_dialog_scale_gui_to_data(const LingotConfigDialog* dialog,
-                                                LingotScale* scale);
+void lingot_gui_config_dialog_scale_gui_to_data(const lingot_config_dialog_t* dialog,
+                                                lingot_scale_t* scale);
 
 // fills the table with the information carried by the structure
-void lingot_gui_config_dialog_scale_data_to_gui(LingotConfigDialog* dialog,
-                                                const LingotScale* scale);
+void lingot_gui_config_dialog_scale_data_to_gui(lingot_config_dialog_t* dialog,
+                                                const lingot_scale_t* scale);
 
 void lingot_gui_config_dialog_scale_callback_change_deviation(GtkWidget *widget,
-                                                              LingotConfigDialog *dialog);
+                                                              lingot_config_dialog_t *dialog);
 void lingot_gui_config_dialog_scale_callback_change_octave(GtkWidget *widget,
-                                                           LingotConfigDialog *dialog);
+                                                           lingot_config_dialog_t *dialog);
 
 #endif /* LINGOT_GUI_CONFIG_DIALOG_SCALE_H */

--- a/src/lingot-gui-config-dialog.c
+++ b/src/lingot-gui-config-dialog.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -30,6 +30,7 @@
 
 #include "lingot-defs.h"
 
+#include "lingot-audio.h"
 #include "lingot-core.h"
 #include "lingot-config.h"
 #include "lingot-gui-mainframe.h"
@@ -40,26 +41,27 @@
 #include "lingot-gui-config-dialog-scale.h"
 #include "lingot-msg.h"
 
-int lingot_gui_config_dialog_apply(LingotConfigDialog*);
-void lingot_gui_config_dialog_close(LingotConfigDialog*);
-void lingot_gui_config_dialog_data_to_gui(LingotConfigDialog*, const LingotConfig*);
+int  lingot_gui_config_dialog_apply(lingot_config_dialog_t*);
+void lingot_gui_config_dialog_close(lingot_config_dialog_t*);
+void lingot_gui_config_dialog_data_to_gui(lingot_config_dialog_t*, const lingot_config_t*);
 void lingot_gui_config_dialog_combo_select_value(GtkWidget* combo, int value);
-int lingot_gui_config_dialog_get_audio_system(GtkComboBoxText* combo);
-void lingot_gui_config_dialog_set_audio_device(GtkComboBoxText* combo, const gchar* device_name);
+int  lingot_gui_config_dialog_get_audio_system(GtkComboBoxText* combo);
+void lingot_gui_config_dialog_set_audio_device(GtkComboBoxText* combo, const char* device_name);
 
+// some static settings
 static const unsigned short frequency_combo_n_octaves = 6;
 static const unsigned short frequency_combo_first_octave = 1;
 
 /* button press event attention routine. */
 
 void lingot_gui_config_dialog_callback_button_cancel(GtkButton *button,
-                                                     LingotConfigDialog* dialog) {
+                                                     lingot_config_dialog_t* dialog) {
     (void)button;           //  Unused parameter.
     lingot_gui_config_dialog_close(dialog);
 }
 
 void lingot_gui_config_dialog_callback_button_ok(GtkButton *button,
-                                                 LingotConfigDialog* dialog) {
+                                                 lingot_config_dialog_t* dialog) {
     (void)button;           //  Unused parameter.
     if (lingot_gui_config_dialog_apply(dialog)) {
         // dumps the current config to the config file
@@ -72,7 +74,7 @@ void lingot_gui_config_dialog_callback_button_ok(GtkButton *button,
 }
 
 void lingot_gui_config_dialog_callback_button_apply(GtkButton *button,
-                                                    LingotConfigDialog* dialog) {
+                                                    lingot_config_dialog_t* dialog) {
     (void)button;           //  Unused parameter.
     if (lingot_gui_config_dialog_apply(dialog)) {
         lingot_gui_config_dialog_data_to_gui(dialog, &dialog->conf);
@@ -80,7 +82,7 @@ void lingot_gui_config_dialog_callback_button_apply(GtkButton *button,
 }
 
 void lingot_gui_config_dialog_callback_button_default(GtkButton *button,
-                                                      LingotConfigDialog* dialog) {
+                                                      lingot_config_dialog_t* dialog) {
     (void)button;           //  Unused parameter.
     lingot_config_restore_default_values(&dialog->conf);
     lingot_gui_config_dialog_data_to_gui(dialog, &dialog->conf);
@@ -88,14 +90,14 @@ void lingot_gui_config_dialog_callback_button_default(GtkButton *button,
 }
 
 void lingot_gui_config_dialog_callback_cancel(GtkWidget *widget,
-                                              LingotConfigDialog* dialog) {
+                                              lingot_config_dialog_t* dialog) {
     (void)widget;           //  Unused parameter.
     //lingot_mainframe_change_config(dialog->mainframe, &dialog->conf_old); // restore old configuration.
     lingot_gui_config_dialog_close(dialog);
 }
 
 void lingot_gui_config_dialog_callback_close(GtkWidget *widget,
-                                             LingotConfigDialog *dialog) {
+                                             lingot_config_dialog_t *dialog) {
     (void)widget;           //  Unused parameter.
     lingot_gui_mainframe_change_config(dialog->mainframe, &dialog->conf_old); // restore old configuration.
     gtk_widget_destroy(dialog->win);
@@ -103,13 +105,13 @@ void lingot_gui_config_dialog_callback_close(GtkWidget *widget,
 }
 
 void lingot_gui_config_dialog_callback_change_input_system(GtkWidget *widget,
-                                                           LingotConfigDialog *dialog) {
+                                                           lingot_config_dialog_t *dialog) {
     (void)widget;           //  Unused parameter.
-    char* text = gtk_combo_box_text_get_active_text(dialog->input_system);
+    gchar* text = gtk_combo_box_text_get_active_text(dialog->input_system);
     int audio_system_index = lingot_audio_system_find_by_name(text);
-    free(text);
+    g_free(text);
 
-    LingotAudioSystemProperties properties;
+    lingot_audio_system_properties_t properties;
 
     if (lingot_audio_system_get_properties(&properties, audio_system_index) == 0) {
         GtkListStore* input_dev_model = GTK_LIST_STORE(
@@ -146,7 +148,9 @@ void lingot_gui_config_dialog_set_audio_system(GtkComboBoxText* combo,
 
     while (valid) {
         gchar *str_data;
-        gtk_tree_model_get(model, &iter, 0, &str_data, -1);
+        gtk_tree_model_get(model, &iter,
+                           0, &str_data,
+                           -1);
         if (!strcmp(str_data, token)) {
             gtk_combo_box_set_active_iter(GTK_COMBO_BOX(combo), &iter);
         }
@@ -156,9 +160,9 @@ void lingot_gui_config_dialog_set_audio_system(GtkComboBoxText* combo,
 }
 
 int lingot_gui_config_dialog_get_audio_system(GtkComboBoxText* combo) {
-    char* text = gtk_combo_box_text_get_active_text(combo);
+    gchar* text = gtk_combo_box_text_get_active_text(combo);
     int result = lingot_audio_system_find_by_name(text);
-    free(text);
+    g_free(text);
     return result;
 }
 
@@ -185,27 +189,31 @@ const gchar* lingot_gui_config_dialog_get_audio_device(const gchar* str) {
 }
 
 void lingot_gui_config_dialog_set_audio_device(GtkComboBoxText* combo,
-                                               const gchar* device_name) {
+                                               const char* device_name) {
 
-    GtkTreeModel* model = GTK_TREE_MODEL(
-                gtk_combo_box_get_model(GTK_COMBO_BOX(combo)));
+    GtkTreeModel* model = GTK_TREE_MODEL(gtk_combo_box_get_model(GTK_COMBO_BOX(combo)));
     GtkTreeIter iter;
-    const gchar* item;
-    const gchar* filtered_item;
-    const gchar* filtered_name = device_name;
+    char* filtered_name = strdup(device_name);
     if (gtk_tree_model_get_iter_first(model, &iter)) {
         do {
-            gtk_tree_model_get(model, &iter, 0, &item, -1);
-            filtered_item = lingot_gui_config_dialog_get_audio_device(item);
+            gchar* item;
+            gtk_tree_model_get(model, &iter,
+                               0, &item,
+                               -1);
+            // if the audio device ID is already in the popup list, we select the text in the list
+            const gchar* filtered_item = lingot_gui_config_dialog_get_audio_device(item);
             if (!strcmp(device_name, filtered_item)) {
-                filtered_name = item;
+                free(filtered_name);
+                filtered_name = strdup(item); // we strdup because we must g_free(), not free()
+                g_free(item);
                 break;
             }
+            g_free(item);
         } while (gtk_tree_model_iter_next(model, &iter));
     }
 
-    gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))),
-                       filtered_name);
+    gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), filtered_name);
+    free(filtered_name);
 }
 
 // extracts the frequency from the text introduced in the entry (which may
@@ -227,7 +235,7 @@ double lingot_gui_config_dialog_get_frequency(const gchar* str) {
     return result;
 }
 
-void lingot_gui_config_dialog_set_frequency(LingotConfigDialog* dialog,
+void lingot_gui_config_dialog_set_frequency(lingot_config_dialog_t* dialog,
                                             GtkComboBoxText* combo, double frequency) {
 
     if (frequency >= 0.0) {
@@ -261,7 +269,7 @@ void lingot_gui_config_dialog_set_frequency(LingotConfigDialog* dialog,
     }
 }
 
-void lingot_gui_config_dialog_populate_frequency_combos(const LingotConfigDialog* dialog) {
+void lingot_gui_config_dialog_populate_frequency_combos(const lingot_config_dialog_t* dialog) {
 
     // TODO: only when necessary
 
@@ -276,7 +284,7 @@ void lingot_gui_config_dialog_populate_frequency_combos(const LingotConfigDialog
     GtkComboBoxText* combo = GTK_COMBO_BOX_TEXT(
                 gtk_combo_box_text_new_with_entry());
 
-    const LingotConfig* const config = &dialog->conf;
+    const lingot_config_t* const config = &dialog->conf;
 
     int i;
     int octave_index;
@@ -300,7 +308,7 @@ void lingot_gui_config_dialog_populate_frequency_combos(const LingotConfigDialog
 }
 
 void lingot_gui_config_dialog_change_combo_frequency(GtkComboBoxText *combo,
-                                                     LingotConfigDialog *dialog) {
+                                                     lingot_config_dialog_t *dialog) {
 
     int index = gtk_combo_box_get_active(GTK_COMBO_BOX(combo));
     if (index >= 0) {
@@ -314,19 +322,19 @@ void lingot_gui_config_dialog_change_combo_frequency(GtkComboBoxText *combo,
 }
 
 void lingot_gui_config_dialog_change_min_frequency(GtkWidget *widget,
-                                                   LingotConfigDialog *dialog) {
+                                                   lingot_config_dialog_t *dialog) {
     lingot_gui_config_dialog_change_combo_frequency(GTK_COMBO_BOX_TEXT(widget),
                                                     dialog);
 }
 
 void lingot_gui_config_dialog_change_max_frequency(GtkWidget *widget,
-                                                   LingotConfigDialog *dialog) {
+                                                   lingot_config_dialog_t *dialog) {
     lingot_gui_config_dialog_change_combo_frequency(GTK_COMBO_BOX_TEXT(widget),
                                                     dialog);
 }
 
 // updates the enabled/disabled status of some widgets depending on the status of the check button
-static void lingot_gui_config_dialog_optimize_check_toggled_update(LingotConfigDialog *dialog) {
+static void lingot_gui_config_dialog_optimize_check_toggled_update(lingot_config_dialog_t *dialog) {
 
     gboolean enabled = !gtk_toggle_button_get_active(
                 GTK_TOGGLE_BUTTON(dialog->optimize_check_button));
@@ -342,7 +350,7 @@ static void lingot_gui_config_dialog_optimize_check_toggled_update(LingotConfigD
 }
 
 void lingot_gui_config_dialog_optimize_check_toggled(GtkWidget *widget,
-                                                     LingotConfigDialog *dialog) {
+                                                     lingot_config_dialog_t *dialog) {
     (void)widget;           //  Unused parameter.
     lingot_gui_config_dialog_optimize_check_toggled_update(dialog);
 }
@@ -356,15 +364,18 @@ void lingot_gui_config_dialog_combo_select_value(GtkWidget* combo, int value) {
 
     while (valid) {
         gchar *str_data;
-        gtk_tree_model_get(model, &iter, 0, &str_data, -1);
-        if (atoi(str_data) == value)
+        gtk_tree_model_get(model, &iter,
+                           0, &str_data,
+                           -1);
+        if (atoi(str_data) == value) {
             gtk_combo_box_set_active_iter(GTK_COMBO_BOX(combo), &iter);
+        }
         g_free(str_data);
         valid = gtk_tree_model_iter_next(model, &iter);
     }
 }
 
-void lingot_gui_config_dialog_data_to_gui(LingotConfigDialog* dialog, const LingotConfig* conf) {
+void lingot_gui_config_dialog_data_to_gui(lingot_config_dialog_t* dialog, const lingot_config_t* conf) {
 
     lingot_gui_config_dialog_set_audio_system(dialog->input_system, conf->audio_system_index);
     lingot_gui_config_dialog_set_audio_device(dialog->input_dev, conf->audio_dev[conf->audio_system_index]);
@@ -385,7 +396,7 @@ void lingot_gui_config_dialog_data_to_gui(LingotConfigDialog* dialog, const Ling
     lingot_gui_config_dialog_scale_data_to_gui(dialog, &conf->scale);
 }
 
-int lingot_gui_config_dialog_gui_to_data(const LingotConfigDialog* dialog, LingotConfig* conf) {
+int lingot_gui_config_dialog_gui_to_data(const lingot_config_dialog_t* dialog, lingot_config_t* conf) {
 
     gchar* text1;
 
@@ -399,7 +410,7 @@ int lingot_gui_config_dialog_gui_to_data(const LingotConfigDialog* dialog, Lingo
                 gtk_entry_get_text(
                     GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dialog->input_dev)))));
 
-    LingotConfigParameterSpec audioDeviceSpec =
+    lingot_config_parameter_spec_t audioDeviceSpec =
             lingot_io_config_get_parameter_spec(LINGOT_PARAMETER_ID_AUDIO_DEV);
 
     if (strlen(audio_device) >= audioDeviceSpec.str_max_len) {
@@ -451,9 +462,9 @@ int lingot_gui_config_dialog_gui_to_data(const LingotConfigDialog* dialog, Lingo
                     GTK_ENTRY(
                         gtk_bin_get_child(
                             GTK_BIN(dialog->maximum_frequency)))));
-    const LingotConfigParameterSpec minimumFrequencySpec =
+    const lingot_config_parameter_spec_t minimumFrequencySpec =
             lingot_io_config_get_parameter_spec(LINGOT_PARAMETER_ID_MINIMUM_FREQUENCY);
-    const LingotConfigParameterSpec maximumFrequencySpec =
+    const lingot_config_parameter_spec_t maximumFrequencySpec =
             lingot_io_config_get_parameter_spec(LINGOT_PARAMETER_ID_MAXIMUM_FREQUENCY);
 
     if (min_freq <= max_freq) {
@@ -488,28 +499,28 @@ int lingot_gui_config_dialog_gui_to_data(const LingotConfigDialog* dialog, Lingo
     return 1;
 }
 
-int lingot_gui_config_dialog_apply(LingotConfigDialog* dialog) {
+int lingot_gui_config_dialog_apply(lingot_config_dialog_t* dialog) {
     return lingot_gui_config_dialog_gui_to_data(dialog, &dialog->conf);
 }
 
-void lingot_gui_config_dialog_destroy(LingotConfigDialog* dialog) {
+void lingot_gui_config_dialog_destroy(lingot_config_dialog_t* dialog) {
     dialog->mainframe->config_dialog = NULL;
     lingot_config_destroy(&dialog->conf);
     lingot_config_destroy(&dialog->conf_old);
     free(dialog);
 }
 
-void lingot_gui_config_dialog_close(LingotConfigDialog* dialog) {
+void lingot_gui_config_dialog_close(lingot_config_dialog_t* dialog) {
     dialog->mainframe->config_dialog = NULL;
     gtk_widget_destroy(dialog->win);
 }
 
-void lingot_gui_config_dialog_show(LingotMainFrame* frame, LingotConfig* config) {
+void lingot_gui_config_dialog_show(lingot_main_frame_t* frame, lingot_config_t* config) {
 
     int i;
     if (frame->config_dialog == NULL) {
 
-        LingotConfigDialog* dialog = malloc(sizeof(LingotConfigDialog));
+        lingot_config_dialog_t* dialog = malloc(sizeof(lingot_config_dialog_t));
 
         dialog->mainframe = frame;
         lingot_config_new(&dialog->conf);
@@ -530,47 +541,29 @@ void lingot_gui_config_dialog_show(LingotMainFrame* frame, LingotConfig* config)
         //gtk_window_set_position(GTK_WINDOW(dialog->win), GTK_WIN_POS_CENTER_ALWAYS);
         dialog->mainframe->config_dialog = dialog;
 
-        dialog->input_system = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "input_system"));
+        dialog->input_system = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "input_system"));
 
         for (i = 0; i < lingot_audio_system_get_count(); ++i) {
             gtk_combo_box_text_append_text(dialog->input_system,
                                            lingot_audio_system_get_name(i));
         }
 
-        dialog->input_dev = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "input_dev"));
-
-        dialog->calculation_rate = GTK_SCALE(
-                    gtk_builder_get_object(builder, "calculation_rate"));
-        dialog->visualization_rate = GTK_SCALE(
-                    gtk_builder_get_object(builder, "visualization_rate"));
-        dialog->noise_threshold = GTK_SCALE(
-                    gtk_builder_get_object(builder, "noise_threshold"));
-        dialog->fft_size = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "fft_size"));
-        dialog->temporal_window = GTK_SPIN_BUTTON(
-                    gtk_builder_get_object(builder, "temporal_window"));
-        dialog->root_frequency_error = GTK_SPIN_BUTTON(
-                    gtk_builder_get_object(builder, "root_frequency_error"));
-        dialog->minimum_frequency = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "minimum_frequency"));
-        dialog->maximum_frequency = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "maximum_frequency"));
-        dialog->notebook = GTK_NOTEBOOK(
-                    gtk_builder_get_object(builder, "notebook1"));
-        dialog->optimize_check_button = GTK_CHECK_BUTTON(
-                    gtk_builder_get_object(builder, "optimize_check_button"));
-        dialog->fft_size_label = GTK_LABEL(
-                    gtk_builder_get_object(builder, "fft_size_label"));
-        dialog->fft_size_units_label = GTK_LABEL(
-                    gtk_builder_get_object(builder, "fft_size_units_label"));
-        dialog->temporal_window_label = GTK_LABEL(
-                    gtk_builder_get_object(builder, "temporal_window_label"));
-        dialog->temporal_window_units_label = GTK_LABEL(
-                    gtk_builder_get_object(builder, "temporal_window_units_label"));
-        dialog->octave = GTK_COMBO_BOX_TEXT(
-                    gtk_builder_get_object(builder, "octave"));
+        dialog->input_dev = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "input_dev"));
+        dialog->calculation_rate = GTK_SCALE(gtk_builder_get_object(builder, "calculation_rate"));
+        dialog->visualization_rate = GTK_SCALE(gtk_builder_get_object(builder, "visualization_rate"));
+        dialog->noise_threshold = GTK_SCALE(gtk_builder_get_object(builder, "noise_threshold"));
+        dialog->fft_size = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "fft_size"));
+        dialog->temporal_window = GTK_SPIN_BUTTON(gtk_builder_get_object(builder, "temporal_window"));
+        dialog->root_frequency_error = GTK_SPIN_BUTTON(gtk_builder_get_object(builder, "root_frequency_error"));
+        dialog->minimum_frequency = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "minimum_frequency"));
+        dialog->maximum_frequency = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "maximum_frequency"));
+        dialog->notebook = GTK_NOTEBOOK(gtk_builder_get_object(builder, "notebook1"));
+        dialog->optimize_check_button = GTK_CHECK_BUTTON(gtk_builder_get_object(builder, "optimize_check_button"));
+        dialog->fft_size_label = GTK_LABEL(gtk_builder_get_object(builder, "fft_size_label"));
+        dialog->fft_size_units_label = GTK_LABEL(gtk_builder_get_object(builder, "fft_size_units_label"));
+        dialog->temporal_window_label = GTK_LABEL(gtk_builder_get_object(builder, "temporal_window_label"));
+        dialog->temporal_window_units_label = GTK_LABEL(gtk_builder_get_object(builder, "temporal_window_units_label"));
+        dialog->octave = GTK_COMBO_BOX_TEXT(gtk_builder_get_object(builder, "octave"));
 
         gtk_combo_box_set_active(GTK_COMBO_BOX(dialog->octave), 4);
 
@@ -584,8 +577,7 @@ void lingot_gui_config_dialog_show(LingotMainFrame* frame, LingotConfig* config)
                         GTK_CELL_LAYOUT(dialog->minimum_frequency), cell_list->data,
                         "markup", 0, NULL);
         }
-        cell_list = gtk_cell_layout_get_cells(
-                    GTK_CELL_LAYOUT(dialog->maximum_frequency));
+        cell_list = gtk_cell_layout_get_cells(GTK_CELL_LAYOUT(dialog->maximum_frequency));
         if (cell_list && cell_list->data) {
             gtk_cell_layout_set_attributes(
                         GTK_CELL_LAYOUT(dialog->maximum_frequency), cell_list->data,
@@ -636,8 +628,7 @@ void lingot_gui_config_dialog_show(LingotMainFrame* frame, LingotConfig* config)
         lingot_gui_config_dialog_data_to_gui(dialog, &dialog->conf);
 
         gtk_widget_show(dialog->win);
-        GtkWidget* scroll = GTK_WIDGET(
-                    gtk_builder_get_object(builder, "scrolledwindow1"));
+        GtkWidget* scroll = GTK_WIDGET(gtk_builder_get_object(builder, "scrolledwindow1"));
         gtk_widget_show_all(scroll);
         g_object_unref(builder);
 

--- a/src/lingot-gui-config-dialog.h
+++ b/src/lingot-gui-config-dialog.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,9 +29,10 @@
 
 #include "lingot-config.h"
 
-typedef struct _LingotConfigDialog LingotConfigDialog;
+/* object forward declaration */
+typedef struct _lingot_main_frame_t lingot_main_frame_t;
 
-struct _LingotConfigDialog {
+typedef struct {
 
     // widgets that contains configuration information.
     GtkComboBoxText* input_system;
@@ -59,15 +60,15 @@ struct _LingotConfigDialog {
     GtkEntry* scale_name;
     GtkTreeView* scale_treeview;
 
-    LingotConfig conf; // provisional configuration.
-    LingotConfig conf_old; // restoration point for cancel.
+    lingot_config_t conf; // provisional configuration.
+    lingot_config_t conf_old; // restoration point for cancel.
 
-    LingotMainFrame* mainframe;
+    lingot_main_frame_t* mainframe;
 
     GtkWidget* win; // window
-};
+} lingot_config_dialog_t;
 
-void lingot_gui_config_dialog_destroy(LingotConfigDialog*);
-void lingot_gui_config_dialog_show(LingotMainFrame* frame, LingotConfig* config);
+void lingot_gui_config_dialog_destroy(lingot_config_dialog_t*);
+void lingot_gui_config_dialog_show(lingot_main_frame_t* frame, lingot_config_t* config);
 
 #endif // LINGOT_GUI_CONFIG_DIALOG_H

--- a/src/lingot-gui-mainframe.c
+++ b/src/lingot-gui-mainframe.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -39,11 +39,11 @@
 #include "lingot-io-config.h"
 #include "lingot-msg.h"
 
-static void lingot_gui_mainframe_draw_gauge_background(cairo_t *cr, LingotMainFrame* frame);
-static void lingot_gui_mainframe_draw_spectrum_background(cairo_t *cr, LingotMainFrame* frame);
-void lingot_gui_mainframe_draw_gauge(cairo_t *cr, LingotMainFrame *);
-void lingot_gui_mainframe_draw_spectrum(cairo_t *cr, LingotMainFrame *);
-void lingot_gui_mainframe_draw_labels(const LingotMainFrame*);
+static void lingot_gui_mainframe_draw_gauge_background(cairo_t *cr, lingot_main_frame_t* frame);
+static void lingot_gui_mainframe_draw_spectrum_background(cairo_t *cr, lingot_main_frame_t* frame);
+void lingot_gui_mainframe_draw_gauge(cairo_t *cr, lingot_main_frame_t *);
+void lingot_gui_mainframe_draw_spectrum(cairo_t *cr, lingot_main_frame_t *);
+void lingot_gui_mainframe_draw_labels(const lingot_main_frame_t*);
 
 // sizes
 
@@ -73,21 +73,17 @@ static gchar* filechooser_config_last_folder = NULL;
 static const gdouble aspect_ratio_spectrum_visible = 1.14;
 static const gdouble aspect_ratio_spectrum_invisible = 2.07;
 
-// TODO: keep here?
-static int closest_note_index = 0;
-static FLT frequency = 0.0;
-
-void lingot_gui_mainframe_callback_redraw_gauge(GtkWidget *w, cairo_t *cr, LingotMainFrame* data) {
+void lingot_gui_mainframe_callback_redraw_gauge(GtkWidget *w, cairo_t *cr, lingot_main_frame_t* data) {
     (void)w;                //  Unused parameter.
     lingot_gui_mainframe_draw_gauge(cr, data);
 }
 
-void lingot_gui_mainframe_callback_redraw_spectrum(GtkWidget* w, cairo_t *cr, LingotMainFrame* frame) {
+void lingot_gui_mainframe_callback_redraw_spectrum(GtkWidget* w, cairo_t *cr, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     lingot_gui_mainframe_draw_spectrum(cr, frame);
 }
 
-void lingot_gui_mainframe_callback_destroy(GtkWidget* w, LingotMainFrame* frame) {
+void lingot_gui_mainframe_callback_destroy(GtkWidget* w, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     g_source_remove(frame->visualization_timer_uid);
     g_source_remove(frame->freq_computation_timer_uid);
@@ -95,7 +91,7 @@ void lingot_gui_mainframe_callback_destroy(GtkWidget* w, LingotMainFrame* frame)
     gtk_main_quit();
 }
 
-void lingot_gui_mainframe_callback_about(GtkWidget* w, LingotMainFrame* frame) {
+void lingot_gui_mainframe_callback_about(GtkWidget* w, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     (void)frame;            //  Unused parameter.
     static const gchar* authors[] = {
@@ -128,7 +124,7 @@ void lingot_gui_mainframe_callback_about(GtkWidget* w, LingotMainFrame* frame) {
     gtk_show_about_dialog(NULL,
                           "name", "Lingot",
                           "version", VERSION,
-                          "copyright", "\xC2\xA9 2004-2019 Iban Cereijo\n\xC2\xA9 2004-2019 Jairo Chapela",
+                          "copyright", "\xC2\xA9 2004-2020 Iban Cereijo\n\xC2\xA9 2004-2019 Jairo Chapela",
                           "comments", _("Accurate and easy to use musical instrument tuner"),
                           "authors", authors,
                           "artists", artists,
@@ -145,7 +141,7 @@ void lingot_gui_mainframe_callback_about(GtkWidget* w, LingotMainFrame* frame) {
     }
 }
 
-void lingot_gui_mainframe_callback_view_spectrum(GtkWidget* w, LingotMainFrame* frame) {
+void lingot_gui_mainframe_callback_view_spectrum(GtkWidget* w, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     gboolean visible = gtk_check_menu_item_get_active(
                 GTK_CHECK_MENU_ITEM(frame->view_spectrum_item));
@@ -159,14 +155,12 @@ void lingot_gui_mainframe_callback_view_spectrum(GtkWidget* w, LingotMainFrame* 
                 aspect_ratio_spectrum_invisible;
     hints.min_aspect = aspect_ratio;
     hints.max_aspect = aspect_ratio;
-    gtk_window_set_geometry_hints(GTK_WINDOW(frame->win), frame->win, &hints,
-                                  GDK_HINT_ASPECT);
-
+    gtk_window_set_geometry_hints(GTK_WINDOW(frame->win), frame->win, &hints, GDK_HINT_ASPECT);
     gtk_widget_set_visible(frame->spectrum_frame, visible);
 }
 
 void lingot_gui_mainframe_callback_config_dialog(GtkWidget* w,
-                                                 LingotMainFrame* frame) {
+                                                 lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     lingot_gui_config_dialog_show(frame, NULL);
 }
@@ -175,7 +169,7 @@ void lingot_gui_mainframe_callback_config_dialog(GtkWidget* w,
 gboolean lingot_gui_mainframe_callback_tout_visualization(gpointer data) {
     unsigned int period;
 
-    LingotMainFrame* frame = (LingotMainFrame*) data;
+    lingot_main_frame_t* frame = (lingot_main_frame_t*) data;
 
     period = (unsigned int) (1000 / frame->conf.visualization_rate);
     frame->visualization_timer_uid = g_timeout_add(period,
@@ -191,7 +185,7 @@ gboolean lingot_gui_mainframe_callback_tout_spectrum_computation_display(
         gpointer data) {
     unsigned int period;
 
-    LingotMainFrame* frame = (LingotMainFrame*) data;
+    lingot_main_frame_t* frame = (lingot_main_frame_t*) data;
 
     period = (unsigned int) (1000 / frame->conf.calculation_rate);
     frame->freq_computation_timer_uid = g_timeout_add(period,
@@ -207,7 +201,7 @@ gboolean lingot_gui_mainframe_callback_tout_spectrum_computation_display(
 /* timeout for a new gauge position computation */
 gboolean lingot_gui_mainframe_callback_gauge_computation(gpointer data) {
     unsigned int period;
-    LingotMainFrame* frame = (LingotMainFrame*) data;
+    lingot_main_frame_t* frame = (lingot_main_frame_t*) data;
 
     period = (unsigned int) (1000 / GAUGE_RATE);
     frame->gauge_computation_uid = g_timeout_add(period,
@@ -218,13 +212,13 @@ gboolean lingot_gui_mainframe_callback_gauge_computation(gpointer data) {
     // ignore continuous component
     if (!lingot_core_thread_is_running(&frame->core) || isnan(freq)
             || (freq <= frame->conf.internal_min_frequency)) {
-        frequency = 0.0;
+        frame->frequency = 0.0;
         lingot_gauge_compute(&frame->gauge, frame->conf.gauge_rest_value);
     } else {
         FLT error_cents; // do not use, unfiltered
-        frequency = lingot_filter_filter_sample(&frame->freq_filter,
+        frame->frequency = lingot_filter_filter_sample(&frame->freq_filter,
                                                 freq);
-        closest_note_index = lingot_config_scale_get_closest_note_index(
+        frame->closest_note_index = lingot_config_scale_get_closest_note_index(
                     &frame->conf.scale, freq, frame->conf.root_frequency_error, &error_cents);
         if (!isnan(error_cents)) {
             lingot_gauge_compute(&frame->gauge, error_cents);
@@ -238,15 +232,15 @@ gboolean lingot_gui_mainframe_callback_gauge_computation(gpointer data) {
 gboolean lingot_gui_mainframe_callback_error_dispatcher(gpointer data) {
     unsigned int period;
     GtkWidget* message_dialog;
-    LingotMainFrame* frame = (LingotMainFrame*) data;
+    lingot_main_frame_t* frame = (lingot_main_frame_t*) data;
 
-    char* error_message = NULL;
-    message_type_t message_type;
+    char error_message[LINGOT_MSG_MAX_SIZE + 1];
+    lingot_msg_type_t message_type;
     int error_code;
     int more_messages;
 
     do {
-        more_messages = lingot_msg_get(&error_message, &message_type, &error_code);
+        more_messages = lingot_msg_pop(error_message, &message_type, &error_code);
 
         if (more_messages) {
             GtkWindow* parent =
@@ -254,7 +248,7 @@ gboolean lingot_gui_mainframe_callback_error_dispatcher(gpointer data) {
                         (frame->config_dialog != NULL) ? frame->config_dialog->win : frame->win);
             GtkButtonsType buttonsType;
 
-            char message[2000];
+            char message[2 * LINGOT_MSG_MAX_SIZE];
             char* message_pointer = message;
 
             message_pointer += snprintf(message_pointer,
@@ -270,7 +264,7 @@ gboolean lingot_gui_mainframe_callback_error_dispatcher(gpointer data) {
                                      "Please check that there are not other processes locking the requested device. Also, consider that some audio servers can sometimes hold the resources for a few seconds since the last time they were used. In such a case, you can try again."));
             }
 
-            if ((message_type == ERROR) && !lingot_core_thread_is_running(&frame->core)) {
+            if ((message_type == LINGOT_MSG_ERROR) && !lingot_core_thread_is_running(&frame->core)) {
                 buttonsType = GTK_BUTTONS_OK;
                 message_pointer +=
                         snprintf(message_pointer,
@@ -284,18 +278,17 @@ gboolean lingot_gui_mainframe_callback_error_dispatcher(gpointer data) {
 
             message_dialog = gtk_message_dialog_new(parent,
                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                    (message_type == ERROR) ? GTK_MESSAGE_ERROR :
-                                                                              ((message_type == WARNING) ? GTK_MESSAGE_WARNING : GTK_MESSAGE_INFO),
+                                                    (message_type == LINGOT_MSG_ERROR) ? GTK_MESSAGE_ERROR :
+                                                                              ((message_type == LINGOT_MSG_WARNING) ? GTK_MESSAGE_WARNING : GTK_MESSAGE_INFO),
                                                     buttonsType, "%s", message);
 
             gtk_window_set_title(GTK_WINDOW(message_dialog),
-                                 (message_type == ERROR) ? _("Error") :
-                                                           ((message_type == WARNING) ? _("Warning") : _("Info")));
+                                 (message_type == LINGOT_MSG_ERROR) ? _("Error") :
+                                                           ((message_type == LINGOT_MSG_WARNING) ? _("Warning") : _("Info")));
             gtk_window_set_icon(GTK_WINDOW(message_dialog),
                                 gtk_window_get_icon(GTK_WINDOW(frame->win)));
             gtk_dialog_run(GTK_DIALOG(message_dialog));
             gtk_widget_destroy(message_dialog);
-            free(error_message);
 
             //			if ((message_type == ERROR) && !frame->core.running) {
             //				lingot_gui_mainframe_callback_config_dialog(NULL, frame);
@@ -312,21 +305,19 @@ gboolean lingot_gui_mainframe_callback_error_dispatcher(gpointer data) {
 }
 
 void lingot_gui_mainframe_callback_open_config(gpointer data,
-                                               LingotMainFrame* frame) {
+                                               lingot_main_frame_t* frame) {
     (void)data;             //  Unused parameter.
     GtkWidget * dialog = gtk_file_chooser_dialog_new(
                 _("Open Configuration File"), GTK_WINDOW(frame->win),
                 GTK_FILE_CHOOSER_ACTION_OPEN, "_Cancel", GTK_RESPONSE_CANCEL,
                 "_Open", GTK_RESPONSE_ACCEPT, NULL);
-    GtkFileFilter *filefilter;
     char config_used = 0;
-    LingotConfig config;
-    filefilter = gtk_file_filter_new();
+    lingot_config_t config;
 
-    gtk_file_filter_set_name(filefilter,
-                             (const gchar *) _("Lingot configuration files"));
+    GtkFileFilter *filefilter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filefilter, (const gchar *) _("Lingot configuration files"));
     gtk_file_filter_add_pattern(filefilter, "*.conf");
-    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filefilter);
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filefilter); // ownership transferer to file_chooser
     gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(dialog), TRUE);
 
     if (filechooser_config_last_folder != NULL) {
@@ -335,40 +326,34 @@ void lingot_gui_mainframe_callback_open_config(gpointer data,
     }
 
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-        char *filename;
-        filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-        free(filechooser_config_last_folder);
-        filechooser_config_last_folder = strdup(
-                    gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog)));
+        g_free(filechooser_config_last_folder);
+        filechooser_config_last_folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog));
+        gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
         lingot_config_new(&config);
         lingot_io_config_load(&config, filename);
         config_used = 1;
         g_free(filename);
     }
     gtk_widget_destroy(dialog);
-    //g_free(filefilter);
 
     if (config_used) {
         lingot_gui_config_dialog_show(frame, &config);
     }
 }
 
-void lingot_gui_mainframe_callback_save_config(gpointer data, LingotMainFrame* frame) {
+void lingot_gui_mainframe_callback_save_config(gpointer data, lingot_main_frame_t* frame) {
     (void)data;             //  Unused parameter.
     GtkWidget *dialog = gtk_file_chooser_dialog_new(
                 _("Save Configuration File"), GTK_WINDOW(frame->win),
                 GTK_FILE_CHOOSER_ACTION_SAVE, "_Cancel", GTK_RESPONSE_CANCEL,
                 "_Save", GTK_RESPONSE_ACCEPT, NULL);
-    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog),
-                                                   TRUE);
-
+    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), _("untitled.conf"));
-    GtkFileFilter* filefilter = gtk_file_filter_new();
 
-    gtk_file_filter_set_name(filefilter,
-                             (const gchar *) _("Lingot configuration files"));
+    GtkFileFilter *filefilter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filefilter, (const gchar *) _("Lingot configuration files"));
     gtk_file_filter_add_pattern(filefilter, "*.conf");
-    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filefilter);
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filefilter); // ownership transferer to file_chooser
     gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(dialog), TRUE);
 
     if (filechooser_config_last_folder != NULL) {
@@ -377,12 +362,9 @@ void lingot_gui_mainframe_callback_save_config(gpointer data, LingotMainFrame* f
     }
 
     if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-        char *filename;
-        filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-        if (filechooser_config_last_folder != NULL)
-            free(filechooser_config_last_folder);
-        filechooser_config_last_folder = strdup(
-                    gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog)));
+        g_free(filechooser_config_last_folder);
+        filechooser_config_last_folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog));
+        gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
         lingot_io_config_save(&frame->conf, filename);
         g_free(filename);
     }
@@ -394,7 +376,7 @@ void lingot_gui_mainframe_callback_window_resize(GtkWidget *widget,
     (void)widget;           //  Unused parameter.
     (void)allocation;       //  Unused parameter.
 
-    const LingotMainFrame* frame = (LingotMainFrame*) data;
+    const lingot_main_frame_t* frame = (lingot_main_frame_t*) data;
 
     GtkAllocation req;
     gtk_widget_get_allocation(frame->gauge_area, &req);
@@ -419,7 +401,7 @@ void lingot_gui_mainframe_callback_window_resize(GtkWidget *widget,
 
 void lingot_gui_mainframe_create(int argc, char *argv[]) {
 
-    LingotMainFrame* frame;
+    lingot_main_frame_t* frame;
 
     if (filechooser_config_last_folder == NULL) {
         char buff[1000];
@@ -427,15 +409,15 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
         filechooser_config_last_folder = strdup(buff);
     }
 
-    frame = malloc(sizeof(LingotMainFrame));
+    frame = malloc(sizeof(lingot_main_frame_t));
 
     frame->config_dialog = NULL;
 
-    LingotConfig* const conf = &frame->conf;
+    lingot_config_t* const conf = &frame->conf;
     lingot_config_new(conf);
     lingot_io_config_load(conf, CONFIG_FILE_NAME);
 
-    lingot_gauge_new(&frame->gauge, conf->gauge_rest_value); // gauge in rest situation
+    lingot_gauge_new(&frame->gauge, GAUGE_RATE, conf->gauge_rest_value); // gauge in rest situation
 
     // ----- FREQUENCY FILTER CONFIGURATION ------
 
@@ -459,26 +441,18 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
     gtk_window_set_default_icon_name("org.nongnu.lingot");
     gtk_window_set_icon_name(GTK_WINDOW(frame->win), "org.nongnu.lingot");
 
-    frame->gauge_area = GTK_WIDGET(
-                gtk_builder_get_object(builder, "gauge_area"));
-    frame->spectrum_area = GTK_WIDGET(
-                gtk_builder_get_object(builder, "spectrum_area"));
+    frame->gauge_area = GTK_WIDGET(gtk_builder_get_object(builder, "gauge_area"));
+    frame->spectrum_area = GTK_WIDGET(gtk_builder_get_object(builder, "spectrum_area"));
 
-    frame->freq_label = GTK_WIDGET(
-                gtk_builder_get_object(builder, "freq_label"));
-    frame->tone_label = GTK_WIDGET(
-                gtk_builder_get_object(builder, "tone_label"));
-    frame->error_label = GTK_WIDGET(
-                gtk_builder_get_object(builder, "error_label"));
+    frame->freq_label = GTK_WIDGET(gtk_builder_get_object(builder, "freq_label"));
+    frame->tone_label = GTK_WIDGET(gtk_builder_get_object(builder, "tone_label"));
+    frame->error_label = GTK_WIDGET(gtk_builder_get_object(builder, "error_label"));
 
-    frame->spectrum_frame = GTK_WIDGET(
-                gtk_builder_get_object(builder, "spectrum_frame"));
-    frame->view_spectrum_item = GTK_WIDGET(
-                gtk_builder_get_object(builder, "spectrum_item"));
+    frame->spectrum_frame = GTK_WIDGET(gtk_builder_get_object(builder, "spectrum_frame"));
+    frame->view_spectrum_item = GTK_WIDGET(gtk_builder_get_object(builder, "spectrum_item"));
     frame->labelsbox = GTK_WIDGET(gtk_builder_get_object(builder, "labelsbox"));
 
-    gtk_check_menu_item_set_active(
-                GTK_CHECK_MENU_ITEM(frame->view_spectrum_item), TRUE);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(frame->view_spectrum_item), TRUE);
 
     // show all
     gtk_widget_show_all(frame->win);
@@ -522,9 +496,8 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
                      G_CALLBACK(lingot_gui_mainframe_callback_window_resize), frame);
 
     GtkAccelGroup* accel_group = gtk_accel_group_new();
-    gtk_widget_add_accelerator(
-                GTK_WIDGET(gtk_builder_get_object(builder, "preferences_item")),
-                "activate", accel_group, 'p', GDK_CONTROL_MASK, GTK_ACCEL_VISIBLE);
+    gtk_widget_add_accelerator(GTK_WIDGET(gtk_builder_get_object(builder, "preferences_item")),
+                               "activate", accel_group, 'p', GDK_CONTROL_MASK, GTK_ACCEL_VISIBLE);
     gtk_window_add_accel_group(GTK_WINDOW(frame->win), accel_group);
 
     unsigned int period;
@@ -545,6 +518,9 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
     frame->error_dispatcher_uid = g_timeout_add(period,
                                                 lingot_gui_mainframe_callback_error_dispatcher, frame);
 
+    frame->closest_note_index = 0;
+    frame->frequency = 0;
+
     lingot_core_new(&frame->core, conf);
     lingot_core_thread_start(&frame->core);
 
@@ -553,7 +529,7 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
     gtk_main();
 }
 
-void lingot_gui_mainframe_destroy(LingotMainFrame* frame) {
+void lingot_gui_mainframe_destroy(lingot_main_frame_t* frame) {
 
     lingot_core_thread_stop(&frame->core);
     lingot_core_destroy(&frame->core);
@@ -587,15 +563,17 @@ typedef struct {
 static void lingot_gui_mainframe_draw_gauge_tic(cairo_t *cr,
                                                 const point_t* gaugeCenter, double radius1, double radius2,
                                                 double angle) {
-    cairo_move_to(cr, gaugeCenter->x + radius1 * sin(angle),
+    cairo_move_to(cr,
+                  gaugeCenter->x + radius1 * sin(angle),
                   gaugeCenter->y - radius1 * cos(angle));
-    cairo_rel_line_to(cr, (radius2 - radius1) * sin(angle),
+    cairo_rel_line_to(cr,
+                      (radius2 - radius1) * sin(angle),
                       (radius1 - radius2) * cos(angle));
     cairo_stroke(cr);
 }
 
 static void lingot_gui_mainframe_draw_gauge_background(cairo_t *cr,
-                                                       LingotMainFrame* frame) {
+                                                       lingot_main_frame_t* frame) {
 
     // normalized dimensions
     static const FLT gauge_gaugeCenterY = 0.94;
@@ -767,7 +745,7 @@ static void lingot_gui_mainframe_draw_gauge_background(cairo_t *cr,
                                         frequencyBarMajorTicRadius, frequencyBarRadius, 0.0);
 }
 
-void lingot_gui_mainframe_draw_gauge(cairo_t *cr, LingotMainFrame* frame) {
+void lingot_gui_mainframe_draw_gauge(cairo_t *cr, lingot_main_frame_t* frame) {
 
     // normalized dimensions
     static const FLT gauge_gaugeCenterY = 0.94;
@@ -853,7 +831,7 @@ static char* lingot_gui_mainframe_format_frequency(FLT freq, char* buff) {
     return buff;
 }
 
-void lingot_gui_mainframe_draw_spectrum_background(cairo_t *cr, LingotMainFrame *frame) {
+void lingot_gui_mainframe_draw_spectrum_background(cairo_t *cr, lingot_main_frame_t *frame) {
 
     const FLT font_size = 8 + spectrum_size_y / 30;
 
@@ -987,7 +965,7 @@ void lingot_gui_mainframe_draw_spectrum_background(cairo_t *cr, LingotMainFrame 
     }
 }
 
-void lingot_gui_mainframe_draw_spectrum(cairo_t *cr, LingotMainFrame* frame) {
+void lingot_gui_mainframe_draw_spectrum(cairo_t *cr, lingot_main_frame_t* frame) {
 
     unsigned int i;
 
@@ -1126,7 +1104,7 @@ void lingot_gui_mainframe_draw_spectrum(cairo_t *cr, LingotMainFrame* frame) {
 
 }
 
-void lingot_gui_mainframe_draw_labels(const LingotMainFrame* frame) {
+void lingot_gui_mainframe_draw_labels(const lingot_main_frame_t* frame) {
 
     char* note_string;
     static char error_string[30];
@@ -1135,7 +1113,7 @@ void lingot_gui_mainframe_draw_labels(const LingotMainFrame* frame) {
 
     // draw note, error and frequency labels
 
-    if (frequency == 0.0) {
+    if (frame->frequency == 0.0) {
         note_string = "---";
         strcpy(error_string, "e = ---");
         strcpy(freq_string, "f = ---");
@@ -1143,12 +1121,12 @@ void lingot_gui_mainframe_draw_labels(const LingotMainFrame* frame) {
     } else {
         note_string =
                 frame->conf.scale.note_name[lingot_config_scale_get_note_index(
-                    &frame->conf.scale, closest_note_index)];
+                    &frame->conf.scale, frame->closest_note_index)];
         sprintf(error_string, "e = %+2.0f cents", frame->gauge.position);
-        sprintf(freq_string, "f = %6.2f Hz", frequency);
+        sprintf(freq_string, "f = %6.2f Hz", frame->frequency);
         sprintf(octave_string, "%d",
                 lingot_config_scale_get_octave(&frame->conf.scale,
-                                               closest_note_index) + 4);
+                                               frame->closest_note_index) + 4);
     }
 
     int font_size = 9 + labelsbox_size_x / 80;
@@ -1171,8 +1149,8 @@ void lingot_gui_mainframe_draw_labels(const LingotMainFrame* frame) {
     g_free(markup);
 }
 
-void lingot_gui_mainframe_change_config(LingotMainFrame* frame,
-                                        LingotConfig* conf) {
+void lingot_gui_mainframe_change_config(lingot_main_frame_t* frame,
+                                        lingot_config_t* conf) {
     lingot_core_thread_stop(&frame->core);
     lingot_core_destroy(&frame->core);
 

--- a/src/lingot-gui-mainframe.h
+++ b/src/lingot-gui-mainframe.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -36,8 +36,7 @@
 
 // Window that contains all controls, graphics, etc. of the tuner.
 
-
-struct _LingotMainFrame {
+typedef struct _lingot_main_frame_t {
 
     // gtk widgets
     GtkWidget* gauge_area;
@@ -51,30 +50,34 @@ struct _LingotMainFrame {
 
     GtkWidget* labelsbox;
 
-    LingotFilter freq_filter;
+    lingot_filter_t freq_filter;
 
-    LingotGauge gauge;
+    lingot_gauge_t gauge;
 
-    LingotCore core;
+    lingot_core_t core;
 
     GtkWidget* win;
 
     GdkColor gauge_color;
     GdkColor spectrum_color;
 
-    LingotConfigDialog* config_dialog;
-    LingotConfig conf;
+    lingot_config_dialog_t* config_dialog;
+    lingot_config_t conf;
 
     // timer uids
     guint visualization_timer_uid;
     guint freq_computation_timer_uid;
     guint gauge_computation_uid;
     guint error_dispatcher_uid;
-};
+
+    // filtered frequency and closest note index in the scale
+    FLT frequency;
+    int closest_note_index;
+} lingot_main_frame_t;
 
 void lingot_gui_mainframe_create(int argc, char *argv[]);
-void lingot_gui_mainframe_destroy(LingotMainFrame*);
+void lingot_gui_mainframe_destroy(lingot_main_frame_t*);
 
-void lingot_gui_mainframe_change_config(LingotMainFrame*, LingotConfig*);
+void lingot_gui_mainframe_change_config(lingot_main_frame_t*, lingot_config_t*);
 
 #endif //LINGOT_GUI_MAIN_FRAME_H

--- a/src/lingot-i18n.h
+++ b/src/lingot-i18n.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *

--- a/src/lingot-io-config-scale.c
+++ b/src/lingot-io-config-scale.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -31,6 +31,7 @@
 #include "lingot-io-config-scale.h"
 #include "lingot-i18n.h"
 #include "lingot-msg.h"
+#include "lingot-defs.h"
 
 int lingot_config_scale_parse_shift(char* char_buffer, double* cents,
                                     short int* numerator, short int* denominator) {
@@ -96,7 +97,7 @@ void lingot_config_scale_format_shift(char* char_buffer, double cents,
     }
 }
 
-int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
+int lingot_config_scale_load_scl(lingot_scale_t* scale, char* filename) {
     FILE* fp;
     int i;
     char* char_buffer_pointer1;
@@ -106,7 +107,7 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
     int line = 0;
     const char* error_format_msg = _("incorrect format");
     const char* error_note_number_msg = _("note number mismatch");
-    const char* exception;
+    const char* _exception;
 
 #   define MAX_LINE_SIZE 1000
 
@@ -122,25 +123,25 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
 
     scale->base_frequency = MID_C_FREQUENCY;
 
-    try
+    _try
     {
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
 
         if (strchr(char_buffer, '!') != char_buffer) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
 
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
 
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
 
         nl = strrchr(char_buffer, '\r');
@@ -153,13 +154,13 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
 
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
         sscanf(char_buffer, "%hu", &scale->notes);
 
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-            throw(error_format_msg)
+            _throw(error_format_msg)
         }
         lingot_config_scale_allocate(scale, scale->notes);
 
@@ -172,13 +173,13 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
 
             line++;
             if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
-                throw(error_note_number_msg)
+                _throw(error_note_number_msg)
             }
 
             char_buffer_pointer1 = strtok(char_buffer, delim);
 
             if (char_buffer_pointer1 == NULL) {
-                throw(error_note_number_msg)
+                _throw(error_note_number_msg)
             }
 
             size_t len = strlen(char_buffer_pointer1);
@@ -186,10 +187,10 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
                                                     &scale->offset_cents[i], &scale->offset_ratios[0][i],
                     &scale->offset_ratios[1][i]);
             if (!r) {
-                throw(error_format_msg)
+                _throw(error_format_msg)
             } else {
                 if (scale->offset_cents[i] <= scale->offset_cents[i - 1]) {
-                    throw(_("the notes must be well ordered"))
+                    _throw(_("the notes must be well ordered"))
                 }
             }
 
@@ -207,11 +208,11 @@ int lingot_config_scale_load_scl(LingotScale* scale, char* filename) {
                 scale->note_name[i] = strdup(char_buffer);
             }
         }
-    } catch {
+    } _catch {
         result = 0;
         char buff[1000];
         snprintf(buff, sizeof(buff), "%s, line %i: %s",
-                 _("Error opening scale file"), line, exception);
+                 _("Error opening scale file"), line, _exception);
         lingot_msg_add_error(buff);
     }
 

--- a/src/lingot-io-config-scale.h
+++ b/src/lingot-io-config-scale.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -25,13 +25,21 @@
 #ifndef LINGOT_IO_CONFIG_SCALE_H
 #define LINGOT_IO_CONFIG_SCALE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-config-scale.h"
 
-int lingot_config_scale_load_scl(LingotScale* scale, char* filename);
 /* The scale argument must *not* be initialized with _new. */
+int lingot_config_scale_load_scl(lingot_scale_t* scale, char* filename);
 
 int lingot_config_scale_parse_shift(char*, double*, short int*, short int*);
 
 void lingot_config_scale_format_shift(char*, double, short int, short int);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LINGOT_IO_CONFIG_SCALE_H

--- a/src/lingot-io-config.c
+++ b/src/lingot-io-config.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -29,6 +29,7 @@
 #include <math.h>
 #include <locale.h>
 
+#include "lingot-defs.h"
 #include "lingot-io-config.h"
 #include "lingot-config-scale.h"
 #include "lingot-msg.h"
@@ -38,12 +39,12 @@
 
 #define N_MAX_OPTIONS 30
 
-static LingotConfigParameterSpec parameters[N_MAX_OPTIONS];
+static lingot_config_parameter_spec_t parameters[N_MAX_OPTIONS];
 static unsigned int parameters_count = 0;
 
 //----------------------------------------------------------------------------
 
-static void lingot_config_add_string_parameter_spec(LingotConfigParameterId id,
+static void lingot_config_add_string_parameter_spec(lingot_config_parameter_id_t id,
                                                     const char* name, unsigned int max_len, int deprecated) {
     parameters[id].id = id;
     parameters[id].type = LINGOT_PARAMETER_TYPE_STRING;
@@ -54,7 +55,7 @@ static void lingot_config_add_string_parameter_spec(LingotConfigParameterId id,
     parameters_count++;
 }
 
-static void lingot_config_add_integer_parameter_spec(LingotConfigParameterId id,
+static void lingot_config_add_integer_parameter_spec(lingot_config_parameter_id_t id,
                                                      const char* name, const char* units, int min, int max, int deprecated) {
     parameters[id].id = id;
     parameters[id].type = LINGOT_PARAMETER_TYPE_INTEGER;
@@ -66,7 +67,7 @@ static void lingot_config_add_integer_parameter_spec(LingotConfigParameterId id,
     parameters_count++;
 }
 
-static void lingot_config_add_double_parameter_spec(LingotConfigParameterId id,
+static void lingot_config_add_double_parameter_spec(lingot_config_parameter_id_t id,
                                                     const char* name, const char* units, double min, double max,
                                                     int deprecated) {
     parameters[id].id = id;
@@ -83,8 +84,8 @@ void lingot_io_config_create_parameter_specs(void) {
 
     int i = 0;
     for (i = 0; i < N_MAX_OPTIONS; i++) {
-        parameters[i].id = (LingotConfigParameterId) -1;
-        parameters[i].type = (LingotConfigParameterType) -1;
+        parameters[i].id = (lingot_config_parameter_id_t) -1;
+        parameters[i].type = (lingot_config_parameter_type_t) -1;
         parameters[i].name = NULL;
         parameters[i].units = NULL;
         parameters[i].deprecated = 0;
@@ -148,15 +149,15 @@ void lingot_io_config_create_parameter_specs(void) {
 
 }
 
-LingotConfigParameterSpec lingot_io_config_get_parameter_spec(
-        LingotConfigParameterId id) {
+lingot_config_parameter_spec_t lingot_io_config_get_parameter_spec(
+        lingot_config_parameter_id_t id) {
     return parameters[(int) id];
 }
 
 //----------------------------------------------------------------------------
 
 // internal parameters mapped to each token in the config file.
-static void lingot_config_map_parameters(LingotConfig* config, void* params[]) {
+static void lingot_config_map_parameters(lingot_config_t* config, void* params[]) {
 
     typedef struct {
         int id;
@@ -195,7 +196,7 @@ static void lingot_config_map_parameters(LingotConfig* config, void* params[]) {
     }
 }
 
-void lingot_io_config_save(LingotConfig* config, const char* filename) {
+void lingot_io_config_save(lingot_config_t* config, const char* filename) {
     unsigned int i;
     FILE* fp;
     char* lc_all;
@@ -291,7 +292,7 @@ typedef enum {
     rs_done
 } reading_scale_step_t;
 
-int lingot_io_config_load(LingotConfig* config, const char* filename) {
+int lingot_io_config_load(lingot_config_t* config, const char* filename) {
     FILE* fp;
     int line;
     unsigned int option_index;
@@ -306,7 +307,7 @@ int lingot_io_config_load(LingotConfig* config, const char* filename) {
     const char* audio_system_name = NULL;
     int parse_errors = 0;
     int scale_errors = 0;
-    LingotScale scale;
+    lingot_scale_t scale;
 
     // restore default values for non specified parameters
     lingot_config_restore_default_values(config);

--- a/src/lingot-io-config.h
+++ b/src/lingot-io-config.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -25,11 +25,15 @@
 #ifndef LINGOT_IO_CONFIG_H
 #define LINGOT_IO_CONFIG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "lingot-config.h"
 #include "lingot-io-config-scale.h"
 
 // configuration parameter identifier
-typedef enum LingotConfigParameterId {
+typedef enum {
     LINGOT_PARAMETER_ID_AUDIO_SYSTEM, //
     LINGOT_PARAMETER_ID_ROOT_FREQUENCY_ERROR, //
     LINGOT_PARAMETER_ID_FFT_SIZE, //
@@ -56,23 +60,21 @@ typedef enum LingotConfigParameterId {
     LINGOT_PARAMETER_ID_AUDIO_DEV_ALSA, //
     LINGOT_PARAMETER_ID_AUDIO_DEV_JACK, //
     LINGOT_PARAMETER_ID_AUDIO_DEV_PULSEAUDIO, //
-} LingotConfigParameterId;
+} lingot_config_parameter_id_t;
 
 // configuration parameter type
-typedef enum LingotConfigParameterType {
+typedef enum {
     LINGOT_PARAMETER_TYPE_STRING,
     LINGOT_PARAMETER_TYPE_INTEGER,
     LINGOT_PARAMETER_TYPE_FLOAT,
     LINGOT_PARAMETER_TYPE_AUDIO_SYSTEM
-} LingotConfigParameterType;
-
-typedef struct _LingotConfigParameterSpec LingotConfigParameterSpec;
+} lingot_config_parameter_type_t;
 
 // configuration parameter specification (id, type, minimum and maximum allowed values, ...)
-struct _LingotConfigParameterSpec {
+typedef struct {
 
-    LingotConfigParameterId id;
-    LingotConfigParameterType type;
+    lingot_config_parameter_id_t id;
+    lingot_config_parameter_type_t type;
     const char* name;
     const char* units;
 
@@ -83,12 +85,17 @@ struct _LingotConfigParameterSpec {
     int int_max;
     double float_min;
     double float_max;
-};
+
+} lingot_config_parameter_spec_t;
 
 void lingot_io_config_create_parameter_specs(void);
-LingotConfigParameterSpec lingot_io_config_get_parameter_spec(LingotConfigParameterId id);
+lingot_config_parameter_spec_t lingot_io_config_get_parameter_spec(lingot_config_parameter_id_t id);
 
-void lingot_io_config_save(LingotConfig*, const char* filename);
-int lingot_io_config_load(LingotConfig*, const char* filename);
+void lingot_io_config_save(lingot_config_t*, const char* filename);
+int lingot_io_config_load(lingot_config_t*, const char* filename);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LINGOT_IO_CONFIG_H

--- a/src/lingot-msg.c
+++ b/src/lingot-msg.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -28,75 +28,96 @@
 
 #include "lingot-msg.h"
 
-#define MAX_MESSAGES 	5
+#define MAX_MESSAGES        10
 
-char message[MAX_MESSAGES][1000];
-message_type_t message_type[MAX_MESSAGES];
-int error_codes[MAX_MESSAGES];
+typedef struct {
+    lingot_msg_type_t type;
+    char message[LINGOT_MSG_MAX_SIZE + 1];
+    int error_code;
+} lingot_msg_t;
 
+// message queue
+lingot_msg_t message[MAX_MESSAGES];
 int front = 0, rear = 0;
 
 pthread_mutex_t message_queue_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-void lingot_msg_add_error(const char* msg) {
-    lingot_msg_add(msg, ERROR, 0);
+
+void lingot_msg_add_error(const char *message)
+{
+    lingot_msg_add_with_code(LINGOT_MSG_ERROR, message, 0);
 }
 
-void lingot_msg_add_error_with_code(const char* msg, int error_code) {
-    lingot_msg_add(msg, ERROR, error_code);
+void lingot_msg_add_error_with_code(const char *message, int error_code)
+{
+    lingot_msg_add_with_code(LINGOT_MSG_ERROR, message, error_code);
 }
 
-void lingot_msg_add_warning(const char* msg) {
-    lingot_msg_add(msg, WARNING, 0);
+void lingot_msg_add_warning(const char *message)
+{
+    lingot_msg_add_with_code(LINGOT_MSG_WARNING, message, 0);
 }
 
-void lingot_msg_add_info(const char* msg) {
-    lingot_msg_add(msg, INFO, 0);
+void lingot_msg_add_info(const char *message)
+{
+    lingot_msg_add_with_code(LINGOT_MSG_INFO, message, 0);
 }
 
-void lingot_msg_add(const char* msg, message_type_t type, int error_code) {
+void lingot_msg_add(lingot_msg_type_t type, const char* msg) {
+    lingot_msg_add_with_code(type, msg, 0);
+}
+
+void lingot_msg_add_with_code(lingot_msg_type_t type, const char* msg, int error_code) {
 
     pthread_mutex_lock(&message_queue_mutex);
     if (front == ((rear + 1) % MAX_MESSAGES)) {
-        fprintf(stderr, "warning: the messages queue is full!\n");
+        fprintf(stderr, "Warning: the messages queue is full!\n");
     } else {
         // check if the message is already in the queue
         int duplicated = 0;
         int i = front;
+        size_t len = strlen(msg);
+        if (len > LINGOT_MSG_MAX_SIZE) {
+            fprintf(stderr, "Warning: message too long. Truncating!\n");
+        }
+
         while (i != rear) {
             i = (i + 1) % MAX_MESSAGES;
-            if (!strcmp(message[i], msg)) {
+            if (!strncmp(message[i].message, msg, LINGOT_MSG_MAX_SIZE)) {
                 duplicated = 1;
-                fprintf(stderr, "warning: duplicated message: %s\n", msg);
+                fprintf(stderr, "Warning: duplicated message: %s\n", msg);
                 break;
             }
         }
 
         if (!duplicated) {
             rear = ((rear + 1) % MAX_MESSAGES);
-            strcpy(message[rear], msg);
-            message_type[rear] = type;
-            error_codes[rear] = error_code;
+            lingot_msg_t* msg_ = &message[rear];
+            msg_->message[0] = 0;
+            strncat(msg_->message, msg, LINGOT_MSG_MAX_SIZE);
+            msg_->type = type;
+            msg_->error_code = error_code;
 
-            if (type != INFO) {
+            if (type != LINGOT_MSG_INFO) {
                 fprintf(stderr, "%s: %s\n",
-                        (type == ERROR) ? "error" : "warning", msg);
+                        (type == LINGOT_MSG_ERROR) ? "Error" : "Warning", msg);
             }
         }
     }
     pthread_mutex_unlock(&message_queue_mutex);
 }
 
-int lingot_msg_get(char** msg, message_type_t* type, int* error_code) {
+int lingot_msg_pop(char *dst, lingot_msg_type_t* type, int* error_code) {
     int result = 0;
-    *msg = NULL;
 
     pthread_mutex_lock(&message_queue_mutex);
     if (front != rear) {
         front = (front + 1) % MAX_MESSAGES;
-        *msg = strdup(message[front]);
-        *type = message_type[front];
-        *error_code = error_codes[front];
+        dst[0] = 0;
+        lingot_msg_t* msg_ = &message[front];
+        strncat(dst, msg_->message, LINGOT_MSG_MAX_SIZE);
+        *type = msg_->type;
+        *error_code = msg_->error_code;
         result = 1;
     }
     pthread_mutex_unlock(&message_queue_mutex);

--- a/src/lingot-msg.h
+++ b/src/lingot-msg.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -22,26 +22,40 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef LINGOT_MESSAGES_H
-#define LINGOT_MESSAGES_H
+#ifndef LINGOT_MSG_H
+#define LINGOT_MSG_H
 
 // asynchronous message handling (thread-safe)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// maximum size per message
+#define LINGOT_MSG_MAX_SIZE 1000
+
 // message types
-typedef enum message_type_t {
-    ERROR = 0,
-    WARNING = 1,
-    INFO = 2
-} message_type_t;
+typedef enum {
+    LINGOT_MSG_ERROR = 0,
+    LINGOT_MSG_WARNING = 1,
+    LINGOT_MSG_INFO = 2,
+    LINGOT_MSG_DEBUG = 3
+} lingot_msg_type_t;
 
 // add messages to the queue
-void lingot_msg_add(const char* message, message_type_t type, int error_code);
 void lingot_msg_add_error(const char* message);
 void lingot_msg_add_error_with_code(const char* message, int error_code);
 void lingot_msg_add_warning(const char* message);
 void lingot_msg_add_info(const char* message);
 
+void lingot_msg_add(lingot_msg_type_t type, const char* message);
+void lingot_msg_add_with_code(lingot_msg_type_t type, const char* message, int error_code);
+
 // gets a message from the queue, it returns 0 if no messages are available
-int lingot_msg_get(char** msg, message_type_t* type, int* error_code);
+int lingot_msg_pop(char* dst, lingot_msg_type_t* type, int* error_code);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/lingot-signal.c
+++ b/src/lingot-signal.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -52,9 +52,9 @@ static FLT lingot_signal_fft_bin_interpolate_quinn2_tau(FLT x) {
                 / (x + 1.0 + 0.816496580927726)));
 }
 
-static FLT lingot_signal_fft_bin_interpolate_quinn2(const LingotComplex y1,
-                                                    const LingotComplex y2,
-                                                    const LingotComplex y3) {
+static FLT lingot_signal_fft_bin_interpolate_quinn2(const lingot_complex_t y1,
+                                                    const lingot_complex_t y2,
+                                                    const lingot_complex_t y3) {
     FLT absy2_2 = y2[0] * y2[0] + y2[1] * y2[1];
     FLT ap = (y3[0] * y2[0] + y3[1] * y2[1]) / absy2_2;
     FLT dp = -ap / (1.0 - ap);
@@ -259,7 +259,7 @@ static FLT lingot_signal_frequency_penalty(FLT freq) {
 // search the fundamental peak given the SPD and its 2nd derivative
 FLT lingot_signal_estimate_fundamental_frequency(const FLT* snr,
                                                  FLT freq,
-                                                 const LingotComplex* fft,
+                                                 const lingot_complex_t* fft,
                                                  unsigned int N,
                                                  unsigned int n_peaks,
                                                  unsigned int lowest_index,
@@ -478,7 +478,7 @@ void lingot_signal_compute_noise_level(const FLT* spd,
     const FLT filter_a[] = { 1.0, c - 1.0 };
     const FLT filter_b[] = { c };
     static char initialized = 0;
-    static LingotFilter filter;
+    static lingot_filter_t filter;
 
     if (! initialized) {
         initialized = 1;

--- a/src/lingot-signal.h
+++ b/src/lingot-signal.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -45,7 +45,7 @@ FLT lingot_signal_frequency_locker(FLT freq, FLT minFrequency);
 
 FLT lingot_signal_estimate_fundamental_frequency(const FLT* snr,
                                                  FLT freq,
-                                                 const LingotComplex* fft,
+                                                 const lingot_complex_t* fft,
                                                  unsigned int N,
                                                  unsigned int n_peaks,
                                                  unsigned int lowest_index,

--- a/src/lingot.c
+++ b/src/lingot.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2004-2019  Iban Cereijo.
+ * Copyright (C) 2004-2020  Iban Cereijo.
  * Copyright (C) 2004-2008  Jairo Chapela.
 
  *
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
         printf("creating file %s ...\n", CONFIG_FILE_NAME);
 
         // new configuration with default values.
-        LingotConfig new_conf;
+        lingot_config_t new_conf;
         lingot_config_new(&new_conf);
         lingot_config_restore_default_values(&new_conf);
         lingot_io_config_save(&new_conf, CONFIG_FILE_NAME);

--- a/test/src/lingot-test-config-scale.c
+++ b/test/src/lingot-test-config-scale.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *
@@ -27,11 +27,11 @@
 
 void lingot_test_config_scale(void) {
 
-    LingotConfig _config;
-    LingotConfig* config = &_config;
+    lingot_config_t _config;
+    lingot_config_t* config = &_config;
     lingot_config_new(config);
     lingot_config_restore_default_values(config);
-    LingotScale* scale = &config->scale;
+    lingot_scale_t* scale = &config->scale;
 
     CU_ASSERT_EQUAL(lingot_config_scale_get_octave(scale, 0), 0);
     CU_ASSERT_EQUAL(lingot_config_scale_get_octave(scale, 1), 0);

--- a/test/src/lingot-test-core.c
+++ b/test/src/lingot-test-core.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *

--- a/test/src/lingot-test-io-config.c
+++ b/test/src/lingot-test-io-config.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *
@@ -35,8 +35,8 @@
 void lingot_test_io_config(void) {
 
     lingot_io_config_create_parameter_specs();
-    LingotConfig _config;
-    LingotConfig* config = &_config;
+    lingot_config_t _config;
+    lingot_config_t* config = &_config;
     lingot_config_new(config);
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(config);

--- a/test/src/lingot-test-main.c
+++ b/test/src/lingot-test-main.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *

--- a/test/src/lingot-test-signal.c
+++ b/test/src/lingot-test-signal.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *

--- a/test/src/lingot-test.c
+++ b/test/src/lingot-test.c
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *

--- a/test/src/lingot-test.h
+++ b/test/src/lingot-test.h
@@ -1,7 +1,7 @@
 /*
  * lingot, a musical instrument tuner.
  *
- * Copyright (C) 2013  Iban Cereijo
+ * Copyright (C) 2013-2020  Iban Cereijo
  *
  * This file is part of lingot.
  *


### PR DESCRIPTION
Closes #34:

* Added the `extern "C"` keywords to the public headers.
* Avoiding some C++ keywords (exception, try, catch, ...) in headers.
* Using snake_case for the types.
* Fixed a potential race condition when started audio thread.
* Made lingot-core struct mainly private.
* Improved synchronized access to results from lingot-core.
* Better interface to lingot-core.
* Small improvements in lingot-msg (efficiency and internal structs).