### PR TITLE
Allowing compilation with more strict standards C99, C11 and  C18:

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,8 +26,9 @@ lingot_SOURCES = \
 	lingot-config-scale.h\
 	lingot-core.c\
 	lingot-core.h\
-	lingot-defs.h\
-	lingot-msg.h\
+        lingot-defs.c\
+        lingot-defs.h\
+        lingot-msg.h\
 	lingot-msg.c\
 	lingot-gui-config-dialog.c\
 	lingot-gui-config-dialog.h\

--- a/src/lingot-audio-alsa.c
+++ b/src/lingot-audio-alsa.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <alsa/asoundlib.h>
+#include <time.h>
 
 #include "lingot-audio.h"
 #include "lingot-defs.h"
@@ -170,7 +171,10 @@ int lingot_audio_alsa_read(lingot_audio_handler_t* audio) {
                                        audio->read_buffer_size_samples);
 
     if (samples_read == -EAGAIN) {
-        usleep(200); // TODO: size up
+        struct timespec wait;
+        wait.tv_sec = 0;
+        wait.tv_nsec = 200000; // TODO: size up
+        nanosleep(&wait, NULL);
         samples_read = 0;
     } else {
         if (samples_read < 0) {
@@ -252,7 +256,7 @@ int lingot_audio_alsa_get_audio_system_properties(
     // the first record is the default device
     char buff[512];
     snprintf(buff, sizeof(buff), "%s <default>", _("Default Device"));
-    device_names_first->name = strdup(buff);
+    device_names_first->name = _strdup(buff);
     device_names_first->next = NULL;
 
     _try
@@ -348,7 +352,7 @@ int lingot_audio_alsa_get_audio_system_properties(
 
                         result->n_devices++;
                         struct device_name_node_t* new_name_node = (struct device_name_node_t*) malloc(sizeof(struct device_name_node_t*));
-                        new_name_node->name = strdup(device_name);
+                        new_name_node->name = _strdup(device_name);
                         new_name_node->next = NULL;
 
                         if (device_names_first == NULL) {

--- a/src/lingot-audio-jack.c
+++ b/src/lingot-audio-jack.c
@@ -220,13 +220,13 @@ int lingot_audio_jack_get_audio_system_properties(
     properties->devices = (const char**) malloc((size_t) properties->n_devices * sizeof(char*));
     char buff[512];
     snprintf(buff, sizeof(buff), "%s <default>", _("Default Port"));
-    properties->devices[0] = strdup(buff);
+    properties->devices[0] = _strdup(buff);
 
     if (ports != NULL) {
         if (properties->n_devices != 0) {
             int i;
             for (i = 0; ports[i] != NULL; i++) {
-                properties->devices[i + 1] = strdup(ports[i]);
+                properties->devices[i + 1] = _strdup(ports[i]);
             }
         }
     }

--- a/src/lingot-audio-oss.c
+++ b/src/lingot-audio-oss.c
@@ -170,7 +170,7 @@ int lingot_audio_oss_get_audio_system_properties(lingot_audio_system_properties_
     result->forced_sample_rate = 0;
     result->n_devices = 1;
     result->devices = (const char**) malloc((unsigned int) result->n_devices * sizeof(char*));
-    result->devices[0] = strdup("/dev/dsp");
+    result->devices[0] = _strdup("/dev/dsp");
 
     result->n_sample_rates = 5;
     result->sample_rates[0] = 8000;

--- a/src/lingot-audio-pulseaudio.c
+++ b/src/lingot-audio-pulseaudio.c
@@ -81,14 +81,14 @@ void lingot_audio_pulseaudio_new(lingot_audio_handler_t* audio, const char* devi
     }
 
     audio_pa->client = pa_simple_new(NULL, // Use the default server.
-                                        "Lingot", // Our application's name.
-                                        PA_STREAM_RECORD, //
-                                        device_name, //
-                                        "Lingot record thread", // Description of our stream.
-                                        &audio_pa->sample_spec, // sample format.
-                                        NULL, // Use default channel map
-                                        &buff, //
-                                        &error);
+                                     "Lingot", // Our application's name.
+                                     PA_STREAM_RECORD, //
+                                     device_name, //
+                                     "Lingot record thread", // Description of our stream.
+                                     &audio_pa->sample_spec, // sample format.
+                                     NULL, // Use default channel map
+                                     &buff, //
+                                     &error);
 
     if (!audio_pa->client) {
         char buff[512];
@@ -200,7 +200,7 @@ int lingot_audio_pulseaudio_get_audio_system_properties(lingot_audio_system_prop
     // the first record is the default source
     char buff[512];
     snprintf(buff, sizeof(buff), "%s <default>", _("Default Source"));
-    device_names_first->name = strdup(buff);
+    device_names_first->name = _strdup(buff);
     device_names_first->next = NULL;
 
     context = NULL;
@@ -323,26 +323,25 @@ static void lingot_audio_pulseaudio_get_source_info_callback(pa_context *c,
         return;
     }
 
-    struct device_name_node_t** device_names_last =
-            (struct device_name_node_t**) userdata;
+    struct device_name_node_t** device_names_last = (struct device_name_node_t**) userdata;
 
-            char buff[512];
-            snprintf(buff, sizeof(buff), "%s <%s>", i->description, i->name);
+    char buff[512];
+    snprintf(buff, sizeof(buff), "%s <%s>", i->description, i->name);
 
-            //	printf("%s <%s>\n", i->description, i->name);
-            //	printf("\tmonitor of: %s\n", i->monitor_of_sink_name);
-            //	printf("\t%i channels, rate %i, format %i\n", i->sample_spec.channels,
-            //			i->sample_spec.rate, i->sample_spec.format);
-            //	printf("\tlags %i\n", i->flags);
+    //	printf("%s <%s>\n", i->description, i->name);
+    //	printf("\tmonitor of: %s\n", i->monitor_of_sink_name);
+    //	printf("\t%i channels, rate %i, format %i\n", i->sample_spec.channels,
+    //			i->sample_spec.rate, i->sample_spec.format);
+    //	printf("\tlags %i\n", i->flags);
 
-            struct device_name_node_t* new_name_node =
-                    (struct device_name_node_t*) malloc(
-                                sizeof(struct device_name_node_t*));
-                    new_name_node->name = strdup(buff);
-                    new_name_node->next = NULL;
+    struct device_name_node_t* new_name_node = (struct device_name_node_t*)
+            malloc(sizeof(struct device_name_node_t*));
 
-                    (*device_names_last)->next = new_name_node;
-                    *device_names_last = new_name_node;
+    new_name_node->name = _strdup(buff);
+    new_name_node->next = NULL;
+
+    (*device_names_last)->next = new_name_node;
+    *device_names_last = new_name_node;
 }
 
 static void lingot_audio_pulseaudio_context_state_callback(pa_context *c,

--- a/src/lingot-config-scale.c
+++ b/src/lingot-config-scale.c
@@ -82,18 +82,18 @@ void lingot_config_scale_restore_default_values(lingot_scale_t* scale) {
     lingot_config_scale_destroy(scale);
 
     // default 12 tones equal-tempered scale hard-coded
-    scale->name = strdup(_("Default equal-tempered scale"));
+    scale->name = _strdup(_("Default equal-tempered scale"));
     lingot_config_scale_allocate(scale, 12);
 
     scale->base_frequency = MID_C_FREQUENCY;
 
-    scale->note_name[0] = strdup(tone_string[0]);
+    scale->note_name[0] = _strdup(tone_string[0]);
     scale->offset_cents[0] = 0.0;
     scale->offset_ratios[0][0] = 1;
     scale->offset_ratios[1][0] = 1; // 1/1
 
     for (i = 1; i < scale->notes; i++) {
-        scale->note_name[i] = strdup(tone_string[i]);
+        scale->note_name[i] = _strdup(tone_string[i]);
         scale->offset_cents[i] = 100.0 * i;
         scale->offset_ratios[0][i] = -1; // not used
         scale->offset_ratios[1][i] = -1; // not used
@@ -107,11 +107,11 @@ void lingot_config_scale_copy(lingot_scale_t* dst, const lingot_scale_t* src) {
 
     *dst = *src;
 
-    dst->name = strdup(src->name);
+    dst->name = _strdup(src->name);
     lingot_config_scale_allocate(dst, dst->notes);
 
     for (i = 0; i < dst->notes; i++) {
-        dst->note_name[i] = strdup(src->note_name[i]);
+        dst->note_name[i] = _strdup(src->note_name[i]);
         dst->offset_cents[i] = src->offset_cents[i];
         dst->offset_ratios[0][i] = src->offset_ratios[0][i];
         dst->offset_ratios[1][i] = src->offset_ratios[1][i];

--- a/src/lingot-defs.c
+++ b/src/lingot-defs.c
@@ -1,0 +1,40 @@
+/*
+ * lingot, a musical instrument tuner.
+ *
+ * Copyright (C) 2004-2020  Iban Cereijo.
+ * Copyright (C) 2004-2008  Jairo Chapela.
+
+ *
+ * This file is part of lingot.
+ *
+ * lingot is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * lingot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lingot; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "lingot-defs.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+char CONFIG_FILE_NAME[];
+
+char* _strdup(const char *s) {
+    char *str;
+    size_t size = strlen(s) + 1;
+    str = malloc(size);
+    if (str) {
+        memcpy(str, s, size);
+    }
+    return str;
+}

--- a/src/lingot-defs.h
+++ b/src/lingot-defs.h
@@ -25,6 +25,11 @@
 #ifndef LINGOT_DEFS_H
 #define LINGOT_DEFS_H
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "../config.h"
 
 // floating point precision.
@@ -32,7 +37,8 @@
 
 #define CONFIG_DIR_NAME             ".config/lingot/"
 #define DEFAULT_CONFIG_FILE_NAME    "lingot.conf"
-extern char CONFIG_FILE_NAME[];
+
+extern char CONFIG_FILE_NAME[200];
 
 #define QUICK_MESSAGES
 
@@ -53,10 +59,18 @@ extern char CONFIG_FILE_NAME[];
 #    define M_PI 3.14159265358979323846
 #endif
 
-// this option allows us to throw exception from loops, it contains a goto
+// This alternative allows us to throw exception from loops, it contains a goto
 // statement, but totally controlled. It fails when trying to indent code.
 //#define _try _exception = 0;do
 //#define _throw(a) {_exception = a;goto catch_label;}
 //#define _catch while (0);catch_label: if (_exception != 0)
+
+// strdup() is not part of the standard. It is POSIX, but we provide our own
+// implementation.
+char* _strdup(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/lingot-gui-config-dialog-scale.c
+++ b/src/lingot-gui-config-dialog-scale.c
@@ -503,7 +503,7 @@ void lingot_gui_config_dialog_scale_gui_to_data(const lingot_config_dialog_t* di
                        -1);
 
     lingot_config_scale_destroy(scale);
-    scale->name = strdup(gtk_entry_get_text(dialog->scale_name));
+    scale->name = _strdup(gtk_entry_get_text(dialog->scale_name));
     scale->base_frequency = freq;
     lingot_config_scale_allocate(scale, (short unsigned) rows);
 
@@ -518,7 +518,7 @@ void lingot_gui_config_dialog_scale_gui_to_data(const lingot_config_dialog_t* di
         g_free(shift_char);
         shift_char = NULL;
 
-        scale->note_name[i] = strdup(name); // we strdup() because we must g_free() name
+        scale->note_name[i] = _strdup(name); // we strdup() because we must g_free() name
         scale->offset_cents[i] = shift;
         scale->offset_ratios[0][i] = shift_num;
         scale->offset_ratios[1][i] = shift_den;

--- a/src/lingot-gui-config-dialog.c
+++ b/src/lingot-gui-config-dialog.c
@@ -166,12 +166,12 @@ int lingot_gui_config_dialog_get_audio_system(GtkComboBoxText* combo) {
     return result;
 }
 
-// extracts the string between <>
+// extracts the string between <> markers
 static const gchar* lingot_gui_config_dialog_get_string(const gchar* str) {
     static char buffer[1024];
 
     const char* delim = "<>";
-    char* str_ = strdup(str);
+    char* str_ = _strdup(str);
     char* token = strtok(str_, delim);
     if ((token == str_) && (strlen(token) != strlen(str))) {
         token = strtok(NULL, delim);
@@ -193,7 +193,7 @@ void lingot_gui_config_dialog_set_audio_device(GtkComboBoxText* combo,
 
     GtkTreeModel* model = GTK_TREE_MODEL(gtk_combo_box_get_model(GTK_COMBO_BOX(combo)));
     GtkTreeIter iter;
-    char* filtered_name = strdup(device_name);
+    char* filtered_name = _strdup(device_name);
     if (gtk_tree_model_get_iter_first(model, &iter)) {
         do {
             gchar* item;
@@ -204,7 +204,7 @@ void lingot_gui_config_dialog_set_audio_device(GtkComboBoxText* combo,
             const gchar* filtered_item = lingot_gui_config_dialog_get_audio_device(item);
             if (!strcmp(device_name, filtered_item)) {
                 free(filtered_name);
-                filtered_name = strdup(item); // we strdup because we must g_free(), not free()
+                filtered_name = _strdup(item); // we strdup because we must g_free(), not free()
                 g_free(item);
                 break;
             }

--- a/src/lingot-gui-mainframe.c
+++ b/src/lingot-gui-mainframe.c
@@ -406,7 +406,7 @@ void lingot_gui_mainframe_create(int argc, char *argv[]) {
     if (filechooser_config_last_folder == NULL) {
         char buff[1000];
         snprintf(buff, sizeof(buff), "%s/%s", getenv("HOME"), CONFIG_DIR_NAME);
-        filechooser_config_last_folder = strdup(buff);
+        filechooser_config_last_folder = _strdup(buff);
     }
 
     frame = malloc(sizeof(lingot_main_frame_t));

--- a/src/lingot-io-config-scale.c
+++ b/src/lingot-io-config-scale.c
@@ -150,7 +150,7 @@ int lingot_config_scale_load_scl(lingot_scale_t* scale, char* filename) {
         nl = strrchr(char_buffer, '\n');
         if (nl)
             *nl = '\0';
-        scale->name = strdup(char_buffer);
+        scale->name = _strdup(char_buffer);
 
         line++;
         if (!fgets(char_buffer, MAX_LINE_SIZE, fp)) {
@@ -164,7 +164,7 @@ int lingot_config_scale_load_scl(lingot_scale_t* scale, char* filename) {
         }
         lingot_config_scale_allocate(scale, scale->notes);
 
-        scale->note_name[0] = strdup("1");
+        scale->note_name[0] = _strdup("1");
         scale->offset_cents[0] = 0.0;
         scale->offset_ratios[0][0] = 1;
         scale->offset_ratios[1][0] = 1; // 1/1
@@ -202,10 +202,10 @@ int lingot_config_scale_load_scl(lingot_scale_t* scale, char* filename) {
                 ++char_buffer_pointer1;
             }
             if (char_buffer_pointer1) {
-                scale->note_name[i] = strdup(char_buffer_pointer1);
+                scale->note_name[i] = _strdup(char_buffer_pointer1);
             } else {
                 sprintf(char_buffer, "%d", i + 1);
-                scale->note_name[i] = strdup(char_buffer);
+                scale->note_name[i] = _strdup(char_buffer);
             }
         }
     } _catch {

--- a/src/lingot-io-config.c
+++ b/src/lingot-io-config.c
@@ -209,7 +209,7 @@ void lingot_io_config_save(lingot_config_t* config, const char* filename) {
     lc_all = setlocale(LC_ALL, NULL);
     // duplicate the string, as the next call to setlocale will destroy it
     if (lc_all) {
-        lc_all = strdup(lc_all);
+        lc_all = _strdup(lc_all);
     }
     setlocale(LC_ALL, "C");
 
@@ -371,7 +371,7 @@ int lingot_io_config_load(lingot_config_t* config, const char* filename) {
                 if (nl) {
                     *nl = '\0';
                 }
-                scale.name = strdup(char_buffer_pointer);
+                scale.name = _strdup(char_buffer_pointer);
                 continue;
             }
             if (!strcmp(char_buffer_pointer, "BASE_FREQUENCY")) {
@@ -405,7 +405,7 @@ int lingot_io_config_load(lingot_config_t* config, const char* filename) {
                         break;
                     }
 
-                    scale.note_name[i] = strdup(char_buffer_pointer);
+                    scale.note_name[i] = _strdup(char_buffer_pointer);
                     char_buffer_pointer = strtok(NULL, delim2);
 
                     if (char_buffer_pointer == NULL) {

--- a/src/lingot.c
+++ b/src/lingot.c
@@ -42,8 +42,6 @@
 #include "lingot-i18n.h"
 #include "lingot-io-config.h"
 
-char CONFIG_FILE_NAME[200];
-
 int main(int argc, char *argv[]) {
 
 #ifdef ENABLE_NLS

--- a/test/src/lingot-test-main.c
+++ b/test/src/lingot-test-main.c
@@ -28,6 +28,7 @@ void lingot_test_core(void);
 #ifndef LINGOT_TEST_USE_LIB
 
 // TODO: lib?
+#include "lingot-defs.c"
 #include "lingot-complex.c"
 #include "lingot-msg.c"
 #include "lingot-config-scale.c"


### PR DESCRIPTION
* Providing own implementation of `strdup()`.
* Avoding `usleep()` in favor of `nanosleep()`.