### PR TITLE
Fix GUI margins & borders to make them more comfortable

### DIFF
--- a/src/lingot-gui-config-dialog.glade
+++ b/src/lingot-gui-config-dialog.glade
@@ -1,95 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">1</property>
     <property name="upper">30</property>
     <property name="value">25.199999999999999</property>
-    <property name="step_increment">1</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment10">
     <property name="lower">1</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment11">
     <property name="lower">4</property>
     <property name="upper">100</property>
     <property name="value">4</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment12">
     <property name="upper">10</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment13">
     <property name="lower">-500</property>
     <property name="upper">500</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment14">
     <property name="lower">-1</property>
     <property name="upper">8</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">1</property>
     <property name="upper">40</property>
     <property name="value">25</property>
-    <property name="step_increment">3</property>
+    <property name="step-increment">3</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">40</property>
     <property name="value">20</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
     <property name="lower">-90</property>
     <property name="upper">90</property>
     <property name="value">27.699999999999999</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="upper">15</property>
-    <property name="value">0.32000000000000001</property>
-    <property name="step_increment">0.01</property>
+    <property name="value">0.32</property>
+    <property name="step-increment">0.01</property>
   </object>
   <object class="GtkDialog" id="dialog1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">lingot configuration</property>
-    <property name="window_position">center-always</property>
-    <property name="type_hint">normal</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+    <property name="window-position">center-always</property>
+    <property name="type-hint">normal</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox5">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
+        <property name="spacing">6</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area5">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button_default">
                 <property name="label" translatable="yes">Default</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Resets the built-in settings, without applying them.</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Resets the built-in settings, without applying them.</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -101,12 +98,12 @@
               <object class="GtkButton" id="button_apply">
                 <property name="label">gtk-apply</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Applies the current changes to the running tuner, but doesn't modify the configuration file. 
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Applies the current changes to the running tuner, but doesn't modify the configuration file. 
 
 Any applied changes can be rolled back pressing Cancel.</property>
-                <property name="use_stock">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -118,10 +115,10 @@ Any applied changes can be rolled back pressing Cancel.</property>
               <object class="GtkButton" id="button_accept">
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Applies the current changes and modifies the configuration file.</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Applies the current changes and modifies the configuration file.</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -133,10 +130,10 @@ Any applied changes can be rolled back pressing Cancel.</property>
               <object class="GtkButton" id="button_cancel">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Rolls back all the previous applied changes and closes the configuration dialog.</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Rolls back all the previous applied changes and closes the configuration dialog.</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -148,238 +145,240 @@ Any applied changes can be rolled back pressing Cancel.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkNotebook" id="notebook1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <child>
+              <!-- n-columns=2 n-rows=3 -->
               <object class="GtkGrid" id="grid1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="border_width">10</property>
-                <property name="row_spacing">10</property>
-                <property name="column_spacing">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">9</property>
+                <property name="margin-top">9</property>
+                <property name="margin-bottom">9</property>
+                <property name="row-spacing">9</property>
+                <property name="column-spacing">9</property>
                 <child>
                   <object class="GtkLabel" id="system1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
-                    <property name="hexpand">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Audio system</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label18">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Audio device</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBoxText" id="input_system">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">Here you can pick the sound system.</property>
-                    <property name="tooltip_text" translatable="yes">Here you can pick the sound system.</property>
+                    <property name="can-focus">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">Here you can pick the sound system.</property>
+                    <property name="tooltip-text" translatable="yes">Here you can pick the sound system.</property>
                     <property name="hexpand">True</property>
                     <signal name="changed" handler="on_combobox_input_architecture_changed" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBoxText" id="input_dev">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">Choose the audio device if you have more than one. If you are using JACK, you can also connect Lingot to a desired source with an external JACK control application.</property>
-                    <property name="tooltip_text" translatable="yes">Choose the audio device if you have more than one. If you are using JACK, you can also connect Lingot to a desired source with an external JACK control application.</property>
-                    <property name="has_entry">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">Choose the audio device if you have more than one. If you are using JACK, you can also connect Lingot to a desired source with an external JACK control application.</property>
+                    <property name="tooltip-text" translatable="yes">Choose the audio device if you have more than one. If you are using JACK, you can also connect Lingot to a desired source with an external JACK control application.</property>
+                    <property name="hexpand">True</property>
+                    <property name="has-entry">True</property>
                     <signal name="changed" handler="on_combobox_input_architecture_changed" swapped="no"/>
                     <child internal-child="entry">
                       <object class="GtkEntry" id="comboboxtext-entry2">
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label4">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">10</property>
-                    <property name="margin_bottom">5</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Select the audio source:</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="input">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Audio input settings. Select here the audio source.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Audio input settings. Select here the audio source.</property>
                 <property name="label" translatable="yes">Capture</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
+              <!-- n-columns=3 n-rows=4 -->
               <object class="GtkGrid" id="grid4">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">11</property>
+                <property name="margin-top">9</property>
+                <property name="margin-bottom">9</property>
                 <property name="hexpand">True</property>
-                <property name="border_width">10</property>
-                <property name="column_spacing">10</property>
+                <property name="row-spacing">6</property>
+                <property name="column-spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label10">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
-                    <property name="hexpand">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Calculation rate</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label15">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Hz</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label11">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Minimum SNR</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label16">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">dB</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">15</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Adjust the following refresh rates:</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label5">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">30</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">9</property>
                     <property name="label" translatable="yes">Adjust the noise level:</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScale" id="noise_threshold">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">Minimum signal-to-noise ratio to consider the captured signal as something relevant. Try to keep this level low, and raise it if you experience problems in very noisy environments. This level is depicted in the spectrum area as a yellow dotted line.</property>
-                    <property name="tooltip_text" translatable="yes">Minimum signal-to-noise ratio to consider the captured signal as something relevant. Try to keep this level low, and raise it if you experience problems in very noisy environments. This level is depicted in the spectrum area as a yellow dotted line.</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">Minimum signal-to-noise ratio to consider the captured signal as something relevant. Try to keep this level low, and raise it if you experience problems in very noisy environments. This level is depicted in the spectrum area as a yellow dotted line.</property>
+                    <property name="tooltip-text" translatable="yes">Minimum signal-to-noise ratio to consider the captured signal as something relevant. Try to keep this level low, and raise it if you experience problems in very noisy environments. This level is depicted in the spectrum area as a yellow dotted line.</property>
+                    <property name="hexpand">True</property>
                     <property name="adjustment">adjustment3</property>
-                    <property name="lower_stepper_sensitivity">on</property>
-                    <property name="round_digits">1</property>
+                    <property name="lower-stepper-sensitivity">on</property>
+                    <property name="round-digits">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScale" id="calculation_rate">
-                    <property name="width_request">100</property>
+                    <property name="width-request">100</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">Number of calculations of the fundamental frequency per second.</property>
-                    <property name="tooltip_text" translatable="yes">Number of calculations of the fundamental frequency per second.</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">Number of calculations of the fundamental frequency per second.</property>
+                    <property name="tooltip-text" translatable="yes">Number of calculations of the fundamental frequency per second.</property>
                     <property name="hexpand">True</property>
                     <property name="adjustment">adjustment1</property>
-                    <property name="round_digits">1</property>
+                    <property name="round-digits">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -389,94 +388,105 @@ Any applied changes can be rolled back pressing Cancel.</property>
             <child type="tab">
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Quick adjustments on the dynamic response and the signal levels.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Quick adjustments on the dynamic response and the signal levels.</property>
                 <property name="label" translatable="yes">Adjustments</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
+              <!-- n-columns=3 n-rows=6 -->
               <object class="GtkGrid" id="table4">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">10</property>
-                <property name="row_spacing">10</property>
-                <property name="column_spacing">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">9</property>
+                <property name="margin-top">9</property>
+                <property name="margin-bottom">9</property>
+                <property name="row-spacing">6</property>
+                <property name="column-spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="temporal_window_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Temporal window</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSpinButton" id="temporal_window">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">This is the most recent amount of data considered for tuning. The longer it is, the more accuracy you can obtain, but also the dynamic response gets slower, regarding you are considering older parts of the signal. Also, if you raise this parameter, the computational cost increases. The size of the buffer, in samples (depending on the effective sample rate), must be greater than or equal to the FFT buffer size.</property>
-                    <property name="tooltip_text" translatable="yes">This is the most recent amount of data considered for tuning. The longer it is, the more accuracy you can obtain, but also the dynamic response gets slower, regarding you are considering older parts of the signal. Also, if you raise this parameter, the computational cost increases. The size of the buffer, in samples (depending on the effective sample rate), must be greater than or equal to the FFT buffer size.</property>
-                    <property name="invisible_char">●</property>
+                    <property name="can-focus">True</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">This is the most recent amount of data considered for tuning. The longer it is, the more accuracy you can obtain, but also the dynamic response gets slower, regarding you are considering older parts of the signal. Also, if you raise this parameter, the computational cost increases. The size of the buffer, in samples (depending on the effective sample rate), must be greater than or equal to the FFT buffer size.</property>
+                    <property name="tooltip-text" translatable="yes">This is the most recent amount of data considered for tuning. The longer it is, the more accuracy you can obtain, but also the dynamic response gets slower, regarding you are considering older parts of the signal. Also, if you raise this parameter, the computational cost increases. The size of the buffer, in samples (depending on the effective sample rate), must be greater than or equal to the FFT buffer size.</property>
+                    <property name="hexpand">True</property>
+                    <property name="invisible-char">●</property>
                     <property name="xalign">1</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
                     <property name="adjustment">adjustment5</property>
                     <property name="digits">3</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="temporal_window_units_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">seconds</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="fft_size_units_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">samples</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="fft_size_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">FFT size</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBoxText" id="fft_size">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">The FFT buffer gives Lingot a first look to the spectrum. Higher values can help Lingot to hook up the correct peak, but it&amp;apos;s also computationally more expensive. Don&amp;apos;t use high values here unless you need to tune high frequencies.</property>
-                    <property name="tooltip_text" translatable="yes">The FFT buffer gives Lingot a first look to the spectrum. Higher values can help Lingot to hook up the correct peak, but it's also computationally more expensive. Don't use high values here unless you need to tune high frequencies.</property>
+                    <property name="can-focus">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">The FFT buffer gives Lingot a first look to the spectrum. Higher values can help Lingot to hook up the correct peak, but it&amp;apos;s also computationally more expensive. Don&amp;apos;t use high values here unless you need to tune high frequencies.</property>
+                    <property name="tooltip-text" translatable="yes">The FFT buffer gives Lingot a first look to the spectrum. Higher values can help Lingot to hook up the correct peak, but it's also computationally more expensive. Don't use high values here unless you need to tune high frequencies.</property>
                     <property name="hexpand">True</property>
                     <items>
                       <item id="&lt;Enter ID&gt;">256</item>
@@ -487,127 +497,132 @@ Any applied changes can be rolled back pressing Cancel.</property>
                     </items>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="optimize_check_button">
                     <property name="label" translatable="yes">Optimize parameters automatically</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup" translatable="yes">Leave this option ON and Lingot will optimize some parameters for you.</property>
-                    <property name="tooltip_text" translatable="yes">Leave this option ON and Lingot will optimize some parameters for you.</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup" translatable="yes">Leave this option ON and Lingot will optimize some parameters for you.</property>
+                    <property name="tooltip-text" translatable="yes">Leave this option ON and Lingot will optimize some parameters for you.</property>
                     <property name="halign">start</property>
-                    <property name="margin_top">10</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="margin-left">9</property>
+                    <property name="hexpand">True</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label9">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
-                    <property name="hexpand">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Minimum note</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label12">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">15</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Maximum note</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBoxText" id="minimum_frequency">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="hexpand">True</property>
-                    <property name="has_entry">True</property>
+                    <property name="has-entry">True</property>
                     <child internal-child="entry">
                       <object class="GtkEntry" id="comboboxtext-entry">
-                        <property name="can_focus">True</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_markup" translatable="yes">This is the lowest frequency you want to tune in this instrument. You can put here either a frequency or select a note from the popup list.</property>
-                        <property name="tooltip_text" translatable="yes">This is the lowest frequency you want to tune in this instrument. You can put here either a frequency or select a note from the popup list.</property>
-                        <property name="invisible_char">●</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-markup" translatable="yes">This is the lowest frequency you want to tune in this instrument. You can put here either a frequency or select a note from the popup list.</property>
+                        <property name="tooltip-text" translatable="yes">This is the lowest frequency you want to tune in this instrument. You can put here either a frequency or select a note from the popup list.</property>
+                        <property name="invisible-char">●</property>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBoxText" id="maximum_frequency">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
                     <property name="active">4</property>
-                    <property name="has_entry">True</property>
+                    <property name="has-entry">True</property>
                     <child internal-child="entry">
                       <object class="GtkEntry" id="comboboxtext-entry10">
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label20">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Hz</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label22">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">10</property>
-                    <property name="label" translatable="yes">Instrument frequency range</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Intrument frequency range</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label6">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-left">9</property>
+                    <property name="margin-right">9</property>
                     <property name="label" translatable="yes">Hz</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
               </object>
@@ -618,117 +633,127 @@ Any applied changes can be rolled back pressing Cancel.</property>
             <child type="tab">
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Basic settings on the frequency finding algorithm. Come here to get better accuracy, frequency range or CPU usage. </property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Basic settings on the frequency finding algorithm. Come here to get better accuracy, frequency range or CPU usage. </property>
                 <property name="label" translatable="yes">Settings</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
+              <!-- n-columns=3 n-rows=3 -->
               <object class="GtkGrid" id="grid2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">9</property>
+                <property name="margin-top">9</property>
+                <property name="margin-bottom">9</property>
+                <property name="row-spacing">6</property>
+                <property name="column-spacing">6</property>
                 <child>
+                  <!-- n-columns=5 n-rows=3 -->
                   <object class="GtkGrid" id="grid3">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="hexpand">True</property>
-                    <property name="border_width">10</property>
-                    <property name="row_spacing">10</property>
-                    <property name="column_spacing">10</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label13">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">9</property>
+                        <property name="margin-right">9</property>
                         <property name="hexpand">False</property>
                         <property name="label" translatable="yes">Name</property>
                         <property name="xalign">0.47999998927116394</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="scale_name">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_markup" translatable="yes">Scale name, only for your information.</property>
-                        <property name="tooltip_text" translatable="yes">Scale name, only for your information.</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-markup" translatable="yes">Scale name, only for your information.</property>
+                        <property name="tooltip-text" translatable="yes">Scale name, only for your information.</property>
                         <property name="hexpand">True</property>
-                        <property name="invisible_char">●</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
+                        <property name="invisible-char">●</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="secondary-icon-activatable">False</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                         <property name="width">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label8">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">cents</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSpinButton" id="root_frequency_error">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_markup" translatable="yes">Applies a shift in frequency to all the notes defined in the table below.</property>
-                        <property name="tooltip_text" translatable="yes">Applies a shift in frequency to all the notes defined in the table below.</property>
-                        <property name="invisible_char">●</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-markup" translatable="yes">Applies a shift in frequency to all the notes defined in the table below.</property>
+                        <property name="tooltip-text" translatable="yes">Applies a shift in frequency to all the notes defined in the table below.</property>
+                        <property name="invisible-char">●</property>
                         <property name="xalign">1</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="secondary-icon-activatable">False</property>
                         <property name="adjustment">adjustment13</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label17">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">10</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">9</property>
+                        <property name="margin-right">9</property>
                         <property name="label" translatable="yes">Deviation</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="octave_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Octave</property>
                       </object>
                       <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">3</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBoxText" id="octave">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_markup" translatable="yes">Octave whose frequencies are being displayed in the table below. Change this parameter if you want to display the assigned frequencies in other octaves, but try to assign the frequencies always to the 4th octave (The 4th octave usually covers the frequencies from 261.63 Hz to 523.25 Hz).</property>
-                        <property name="tooltip_text" translatable="yes">Octave whose frequencies are being displayed in the table below. Change this parameter if you want to display the assigned frequencies in other octaves, but try to assign the frequencies always to the 4th octave (The 4th octave usually covers the frequencies from 261.63 Hz to 523.25 Hz).</property>
+                        <property name="can-focus">False</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-markup" translatable="yes">Octave whose frequencies are being displayed in the table below. Change this parameter if you want to display the assigned frequencies in other octaves, but try to assign the frequencies always to the 4th octave (The 4th octave usually covers the frequencies from 261.63 Hz to 523.25 Hz).</property>
+                        <property name="tooltip-text" translatable="yes">Octave whose frequencies are being displayed in the table below. Change this parameter if you want to display the assigned frequencies in other octaves, but try to assign the frequencies always to the 4th octave (The 4th octave usually covers the frequencies from 261.63 Hz to 523.25 Hz).</property>
                         <property name="active">0</property>
                         <items>
                           <item>0</item>
@@ -741,61 +766,78 @@ Any applied changes can be rolled back pressing Cancel.</property>
                         </items>
                       </object>
                       <packing>
-                        <property name="left_attach">4</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">4</property>
+                        <property name="top-attach">1</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
+                  <!-- n-columns=3 n-rows=3 -->
                   <object class="GtkGrid" id="grid5">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="vexpand">True</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">6</property>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="height_request">260</property>
+                        <property name="height-request">260</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="border_width">6</property>
-                        <property name="hscrollbar_policy">never</property>
-                        <property name="shadow_type">out</property>
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="shadow-type">out</property>
                         <child>
                           <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="vbox3">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">6</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkButtonBox" id="vbuttonbox1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
-                            <property name="spacing">4</property>
+                            <property name="spacing">6</property>
+                            <property name="layout-style">start</property>
                             <child>
                               <object class="GtkButton" id="button_scale_add">
                                 <property name="label" translatable="yes">Insert</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Adds a new note to the list, just above the selected line, or appends it to the end if no line is selected. Is not possible to add a note before the reference (the first) one. You can also use the Insert key on the table beside.</property>
-                                <property name="tooltip_text" translatable="yes">Adds a new note to the list, just above the selected line, or appends it to the end if no line is selected. Is not possible to add a note before the reference (the first) one. You can also use the Insert key on the table beside.</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-markup" translatable="yes">Adds a new note to the list, just above the selected line, or appends it to the end if no line is selected. Is not possible to add a note before the reference (the first) one. You can also use the Insert key on the table beside.</property>
+                                <property name="tooltip-text" translatable="yes">Adds a new note to the list, just above the selected line, or appends it to the end if no line is selected. Is not possible to add a note before the reference (the first) one. You can also use the Insert key on the table beside.</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -807,11 +849,11 @@ Any applied changes can be rolled back pressing Cancel.</property>
                               <object class="GtkButton" id="button_scale_del">
                                 <property name="label" translatable="yes">Delete</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Deletes the selected notes. The reference note, i.e., the first one, cannot be removed. You can also use the Delete key on the table beside.</property>
-                                <property name="tooltip_text" translatable="yes">Deletes the selected notes. The reference note, i.e., the first one, cannot be removed. You can also use the Delete key on the table beside.</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-markup" translatable="yes">Deletes the selected notes. The reference note, i.e., the first one, cannot be removed. You can also use the Delete key on the table beside.</property>
+                                <property name="tooltip-text" translatable="yes">Deletes the selected notes. The reference note, i.e., the first one, cannot be removed. You can also use the Delete key on the table beside.</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -823,11 +865,11 @@ Any applied changes can be rolled back pressing Cancel.</property>
                               <object class="GtkButton" id="button_scale_import">
                                 <property name="label" translatable="yes">Import</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Imports the scale from an external .scl file, with the Scala project format (http://www.huygens-fokker.org/scala/)</property>
-                                <property name="tooltip_text" translatable="yes">Imports the scale from an external .scl file, with the Scala project format (http://www.huygens-fokker.org/scala/)</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-markup" translatable="yes">Imports the scale from an external .scl file, with the Scala project format (http://www.huygens-fokker.org/scala/)</property>
+                                <property name="tooltip-text" translatable="yes">Imports the scale from an external .scl file, with the Scala project format (http://www.huygens-fokker.org/scala/)</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -847,15 +889,57 @@ Any applied changes can be rolled back pressing Cancel.</property>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -865,13 +949,13 @@ Any applied changes can be rolled back pressing Cancel.</property>
             <child type="tab">
               <object class="GtkLabel" id="label7">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Lingot is an universal tuner, it can tune any instrument according to the scale you define here.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Lingot is an universal tuner, it can tune any instrument according to the scale you define here.</property>
                 <property name="label" translatable="yes">Scale</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -894,23 +978,23 @@ Any applied changes can be rolled back pressing Cancel.</property>
     <property name="lower">1</property>
     <property name="upper">120</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="upper">22050</property>
-    <property name="step_increment">1</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment8">
     <property name="upper">50</property>
     <property name="value">29.199999999999999</property>
-    <property name="step_increment">1</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment9">
     <property name="lower">1</property>
     <property name="upper">5</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
 </interface>

--- a/src/lingot-gui-mainframe.glade
+++ b/src/lingot-gui-mainframe.glade
@@ -175,31 +175,174 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=1 -->
-          <object class="GtkGrid" id="grid1">
+          <object class="GtkPaned" id="vertical_paned">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-left">9</property>
-            <property name="margin-right">9</property>
-            <property name="margin-top">9</property>
-            <property name="row-spacing">6</property>
-            <property name="column-spacing">6</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkFrame" id="gauge_frame">
+              <object class="GtkPaned" id="horizontal_paned">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">9</property>
+                <property name="margin-top">9</property>
+                <child>
+                  <object class="GtkFrame" id="gauge_frame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkDrawingArea" id="gauge_area">
+                        <property name="width-request">184</property>
+                        <property name="height-request">115</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-text" translatable="yes">Shows the error in cents in a visual way. The range will depend on the maximum distance between each two notes in the scale defined in the Lingot settings. Try to provide scales with low maximum distance, i.e. with enough notes, to have a higher resolution in this gauge (12 notes per scale is a safe option).</property>
+                        <property name="margin-left">6</property>
+                        <property name="margin-right">6</property>
+                        <property name="margin-top">6</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">6</property>
+                        <property name="margin-right">6</property>
+                        <property name="label" translatable="yes">Deviation</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="resize">True</property>
+                    <property name="shrink">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkAlignment" id="alignment3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">6</property>
+                        <property name="margin-right">6</property>
+                        <property name="margin-top">6</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="left-padding">12</property>
+                        <child>
+                          <object class="GtkBox" id="labelsbox">
+                            <property name="width-request">150</property>
+                            <property name="height-request">115</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="resize-mode">immediate</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel" id="freq_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-text" translatable="yes">Estimated ground frequency in hertzs.</property>
+                                <property name="label" translatable="yes">f = ---</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="tone_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-markup" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
+                                <property name="tooltip-text" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
+                                <property name="label" translatable="yes">---</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="error_label">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="tooltip-markup" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
+                                <property name="tooltip-text" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
+                                <property name="label" translatable="yes">e = ---</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">6</property>
+                        <property name="margin-right">6</property>
+                        <property name="label" translatable="yes">Tone</property>
+                        <property name="use-markup">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="resize">True</property>
+                    <property name="shrink">False</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">True</property>
+                <property name="shrink">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="spectrum_frame">
+                <property name="height-request">130</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">9</property>
+                <property name="margin-right">9</property>
+                <property name="margin-bottom">9</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <object class="GtkDrawingArea" id="gauge_area">
-                    <property name="width-request">184</property>
-                    <property name="height-request">115</property>
+                  <object class="GtkDrawingArea" id="spectrum_area">
+                    <property name="width-request">300</property>
+                    <property name="height-request">120</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="has-tooltip">True</property>
-                    <property name="tooltip-text" translatable="yes">Shows the error in cents in a visual way. The range will depend on the maximum distance between each two notes in the scale defined in the Lingot settings. Try to provide scales with low maximum distance, i.e. with enough notes, to have a higher resolution in this gauge (12 notes per scale is a safe option).</property>
+                    <property name="tooltip-text" translatable="yes">This area shows the signal-to-noise ratio (SNR) of the captured signal. The ground frequency computed is shown with a red vertical line, the target frequency as a vertical blue line, and the noise threshold with a horizontal dotted yellow line.</property>
                     <property name="margin-left">6</property>
                     <property name="margin-right">6</property>
                     <property name="margin-top">6</property>
@@ -209,151 +352,26 @@
                   </object>
                 </child>
                 <child type="label">
-                  <object class="GtkLabel" id="label1">
+                  <object class="GtkLabel" id="label2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Deviation</property>
+                    <property name="margin-left">6</property>
+                    <property name="margin-right">6</property>
+                    <property name="label" translatable="yes">Spectrum</property>
                     <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-                <property name="width">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="frame3">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="label-xalign">0</property>
-                <property name="shadow-type">in</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment3">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <child>
-                      <object class="GtkBox" id="labelsbox">
-                        <property name="width-request">150</property>
-                        <property name="height-request">115</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="resize-mode">immediate</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkLabel" id="freq_label">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="has-tooltip">True</property>
-                            <property name="tooltip-text" translatable="yes">Estimated ground frequency in hertzs.</property>
-                            <property name="label" translatable="yes">f = ---</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="tone_label">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="has-tooltip">True</property>
-                            <property name="tooltip-markup" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
-                            <property name="tooltip-text" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
-                            <property name="label" translatable="yes">---</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="error_label">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="has-tooltip">True</property>
-                            <property name="tooltip-markup" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
-                            <property name="tooltip-text" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
-                            <property name="label" translatable="yes">e = ---</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label3">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Tone</property>
-                    <property name="use-markup">True</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">0</property>
+                <property name="resize">True</property>
+                <property name="shrink">False</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkFrame" id="spectrum_frame">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-left">9</property>
-            <property name="margin-right">9</property>
-            <property name="margin-bottom">9</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="label-xalign">0</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkDrawingArea" id="spectrum_area">
-                <property name="width-request">300</property>
-                <property name="height-request">120</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="has-tooltip">True</property>
-                <property name="tooltip-text" translatable="yes">This area shows the signal-to-noise ratio (SNR) of the captured signal. The ground frequency computed is shown with a red vertical line, the target frequency as a vertical blue line, and the noise threshold with a horizontal dotted yellow line.</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-              </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Spectrum</property>
-                <property name="use-markup">True</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/lingot-gui-mainframe.glade
+++ b/src/lingot-gui-mainframe.glade
@@ -1,76 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkWindow" id="window1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="no_show_all">True</property>
-    <property name="border_width">6</property>
+    <property name="can-focus">False</property>
+    <property name="no-show-all">True</property>
     <property name="title" translatable="yes">lingot</property>
-    <property name="window_position">center</property>
+    <property name="window-position">center</property>
     <accel-groups>
       <group name="accelgroup1"/>
     </accel-groups>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
         <child>
           <object class="GtkMenuBar" id="menubar1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkMenuItem" id="menuitem1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_File</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="open_config_item">
                         <property name="label">gtk-open</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Opens an external configuration file.</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-text" translatable="yes">Opens an external configuration file.</property>
+                        <property name="use-underline">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="accel-group">accelgroup1</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="save_config_item">
                         <property name="label">gtk-save-as</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Saves the running configuration to an external file.</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-text" translatable="yes">Saves the running configuration to an external file.</property>
+                        <property name="use-underline">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="accel-group">accelgroup1</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="quit_item">
                         <property name="label">gtk-quit</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="accel-group">accelgroup1</property>
                       </object>
                     </child>
                   </object>
@@ -80,21 +77,21 @@
             <child>
               <object class="GtkMenuItem" id="menuitem2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Edit</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="preferences_item">
                         <property name="label">gtk-preferences</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="accel-group">accelgroup1</property>
                       </object>
                     </child>
                   </object>
@@ -104,40 +101,40 @@
             <child>
               <object class="GtkMenuItem" id="menuitem3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_View</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu3">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkCheckMenuItem" id="gauge_item">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Show gauge</property>
                         <property name="active">True</property>
-                        <property name="draw_as_radio">True</property>
+                        <property name="draw-as-radio">True</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkCheckMenuItem" id="strobe_disc_item">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Show strobe disc</property>
-                        <property name="draw_as_radio">True</property>
+                        <property name="draw-as-radio">True</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkCheckMenuItem" id="spectrum_item">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Show spectrum</property>
                         <property name="active">True</property>
                       </object>
@@ -149,21 +146,21 @@
             <child>
               <object class="GtkMenuItem" id="menuitem4">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="menu4">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="about_item">
                         <property name="label">gtk-about</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <property name="accel_group">accelgroup1</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="accel-group">accelgroup1</property>
                       </object>
                     </child>
                   </object>
@@ -178,179 +175,185 @@
           </packing>
         </child>
         <child>
-          <object class="GtkPaned" id="vertical_paned">
+          <!-- n-columns=3 n-rows=1 -->
+          <object class="GtkGrid" id="grid1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">9</property>
+            <property name="margin-right">9</property>
+            <property name="margin-top">9</property>
+            <property name="row-spacing">6</property>
+            <property name="column-spacing">6</property>
             <child>
-              <object class="GtkPaned" id="horizontal_paned">
+              <object class="GtkFrame" id="gauge_frame">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkFrame" id="gauge_frame">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">in</property>
-                    <child>
-                      <object class="GtkDrawingArea" id="gauge_area">
-                        <property name="width_request">184</property>
-                        <property name="height_request">115</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_text" translatable="yes">Shows the error in cents in a visual way. The range will depend on the maximum distance between each two notes in the scale defined in the Lingot settings. Try to provide scales with low maximum distance, i.e. with enough notes, to have a higher resolution in this gauge (12 notes per scale is a safe option).</property>
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel" id="label1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Deviation</property>
-                        <property name="use_markup">True</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="resize">True</property>
-                    <property name="shrink">False</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkFrame" id="frame3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">in</property>
-                    <child>
-                      <object class="GtkAlignment" id="alignment3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
-                        <child>
-                          <object class="GtkBox" id="labelsbox">
-                            <property name="width_request">150</property>
-                            <property name="height_request">115</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="resize_mode">immediate</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel" id="freq_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_text" translatable="yes">Estimated ground frequency in hertzs.</property>
-                                <property name="label" translatable="yes">f = ---</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="tone_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
-                                <property name="tooltip_text" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
-                                <property name="label" translatable="yes">---</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="error_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_tooltip">True</property>
-                                <property name="tooltip_markup" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
-                                <property name="tooltip_text" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
-                                <property name="label" translatable="yes">e = ---</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel" id="label3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Tone</property>
-                        <property name="use_markup">True</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="resize">True</property>
-                    <property name="shrink">False</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="spectrum_frame">
-                <property name="height_request">130</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">in</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">in</property>
                 <child>
-                  <object class="GtkDrawingArea" id="spectrum_area">
-                    <property name="width_request">300</property>
-                    <property name="height_request">120</property>
+                  <object class="GtkDrawingArea" id="gauge_area">
+                    <property name="width-request">184</property>
+                    <property name="height-request">115</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_text" translatable="yes">This area shows the signal-to-noise ratio (SNR) of the captured signal. The ground frequency computed is shown with a red vertical line, the target frequency as a vertical blue line, and the noise threshold with a horizontal dotted yellow line.</property>
+                    <property name="can-focus">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Shows the error in cents in a visual way. The range will depend on the maximum distance between each two notes in the scale defined in the Lingot settings. Try to provide scales with low maximum distance, i.e. with enough notes, to have a higher resolution in this gauge (12 notes per scale is a safe option).</property>
+                    <property name="margin-left">6</property>
+                    <property name="margin-right">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                   </object>
                 </child>
                 <child type="label">
-                  <object class="GtkLabel" id="label2">
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Spectrum</property>
-                    <property name="use_markup">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Deviation</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame3">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkBox" id="labelsbox">
+                        <property name="width-request">150</property>
+                        <property name="height-request">115</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="resize-mode">immediate</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="freq_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="has-tooltip">True</property>
+                            <property name="tooltip-text" translatable="yes">Estimated ground frequency in hertzs.</property>
+                            <property name="label" translatable="yes">f = ---</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="tone_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="has-tooltip">True</property>
+                            <property name="tooltip-markup" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
+                            <property name="tooltip-text" translatable="yes">Closest note to the estimated frequency, according to the scale defined in the Lingot settings.</property>
+                            <property name="label" translatable="yes">---</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="error_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="has-tooltip">True</property>
+                            <property name="tooltip-markup" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
+                            <property name="tooltip-text" translatable="yes">Error in cents between the estimated frequency and the closest note according to the scale defined in the Lingot settings.</property>
+                            <property name="label" translatable="yes">e = ---</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Tone</property>
+                    <property name="use-markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">2</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="spectrum_frame">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">9</property>
+            <property name="margin-right">9</property>
+            <property name="margin-bottom">9</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkDrawingArea" id="spectrum_area">
+                <property name="width-request">300</property>
+                <property name="height-request">120</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="has-tooltip">True</property>
+                <property name="tooltip-text" translatable="yes">This area shows the signal-to-noise ratio (SNR) of the captured signal. The ground frequency computed is shown with a red vertical line, the target frequency as a vertical blue line, and the noise threshold with a horizontal dotted yellow line.</property>
+                <property name="margin-left">6</property>
+                <property name="margin-right">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Spectrum</property>
+                <property name="use-markup">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/36348486/127778962-1634d5ba-d642-4c58-9803-4d7e4552623a.png)

After:
![image](https://user-images.githubusercontent.com/36348486/127779170-31ad2692-94be-49af-8a06-e08c9594e5ea.png)

- Menu bar no longer sticks out because of (potentially) improperly assigned border
- Group boxes are no longer squeezed up against each other
- Spacing within settings widgets is no longer inconsistent