### PR TITLE
Adjust spectrum range to isntrument range

### DIFF
--- a/.gdb_history
+++ b/.gdb_history
@@ -1,0 +1,3 @@
+r
+backtrace
+backtrace

--- a/.gdb_history
+++ b/.gdb_history
@@ -1,3 +1,0 @@
-r
-backtrace
-backtrace

--- a/src/lingot-gui-gauge.c
+++ b/src/lingot-gui-gauge.c
@@ -278,6 +278,7 @@ gboolean lingot_gui_gauge_redraw(GtkWidget *w, cairo_t *cr, lingot_main_frame_t*
 
     const double normalized_error = frame->gauge_pos / frame->conf.gauge_range;
     const double angle = 2.0 * normalized_error * overtureAngle;
+
     cairo_set_line_width(cr, gaugeStroke);
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
     lingot_gui_mainframe_cairo_set_source_argb(cr, gauge_gaugeShadowColor);

--- a/src/lingot-gui-mainframe.c
+++ b/src/lingot-gui-mainframe.c
@@ -173,6 +173,7 @@ void lingot_gui_mainframe_callback_view_gauge(GtkWidget* w, lingot_main_frame_t*
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_gauge_item);
     if (on) {
+      gtk_widget_set_visible(frame->gauge_frame, 1);
       gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
       gtk_check_menu_item_set_active(frame->view_none_item, 0);
     }
@@ -186,6 +187,8 @@ void lingot_gui_mainframe_callback_view_none(GtkWidget* w, lingot_main_frame_t* 
     if (on) {
       gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
       gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
+      gtk_widget_set_visible(frame->gauge_frame, 0);
+
     }
     lingot_gui_mainframe_update_gauge_area_tooltip(frame);
 }
@@ -194,6 +197,7 @@ void lingot_gui_mainframe_callback_view_strobe_disc(GtkWidget* w, lingot_main_fr
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_strobe_disc_item);
     if (on) {
+      gtk_widget_set_visible(frame->gauge_frame, 1);
       gtk_check_menu_item_set_active(frame->view_none_item, 0);
       gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
     }
@@ -532,6 +536,8 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
     frame->error_label = GTK_LABEL(gtk_builder_get_object(builder, "error_label"));
 
     frame->spectrum_frame = GTK_WIDGET(gtk_builder_get_object(builder, "spectrum_frame"));
+    frame->gauge_frame = GTK_WIDGET(gtk_builder_get_object(builder, "gauge_frame"));
+
     frame->view_spectrum_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "spectrum_item"));
     frame->view_gauge_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "gauge_item"));
     frame->view_none_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "none_item"));

--- a/src/lingot-gui-mainframe.c
+++ b/src/lingot-gui-mainframe.c
@@ -78,6 +78,7 @@ void lingot_gui_mainframe_callback_hide(GtkWidget* w, const lingot_main_frame_t*
     ui_settings.win_width = win_width;
     ui_settings.win_height = win_height;
     ui_settings.spectrum_visible = gtk_check_menu_item_get_active(frame->view_spectrum_item);
+
     ui_settings.gauge_visible = gtk_check_menu_item_get_active(frame->view_gauge_item);
 
     ui_settings.horizontal_paned_pos = gtk_paned_get_position(frame->horizontal_paned);
@@ -162,6 +163,17 @@ void lingot_gui_mainframe_callback_view_spectrum(GtkWidget* w, lingot_main_frame
     gtk_widget_set_visible(frame->spectrum_frame, visible);
 }
 
+
+void lingot_gui_mainframe_callback_view_deviation(GtkWidget* w, lingot_main_frame_t* frame) {
+    (void)w;                //  Unused parameter.
+    gboolean on = gtk_check_menu_item_get_active(frame->view_deviation_item);
+    if (on) {
+      gtk_widget_set_visible(frame->gauge_frame, 1);
+    } else {
+      gtk_widget_set_visible(frame->gauge_frame, 0);
+    }
+}
+
 void lingot_gui_mainframe_update_gauge_area_tooltip(lingot_main_frame_t* frame) {
     gtk_widget_set_tooltip_text(frame->gauge_area,
                                 gtk_check_menu_item_get_active(frame->view_gauge_item) ?
@@ -173,22 +185,7 @@ void lingot_gui_mainframe_callback_view_gauge(GtkWidget* w, lingot_main_frame_t*
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_gauge_item);
     if (on) {
-      gtk_widget_set_visible(frame->gauge_frame, 1);
       gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
-      gtk_check_menu_item_set_active(frame->view_none_item, 0);
-    }
-    lingot_gui_mainframe_update_gauge_area_tooltip(frame);
-}
-
-
-void lingot_gui_mainframe_callback_view_none(GtkWidget* w, lingot_main_frame_t* frame) {
-    (void)w;                //  Unused parameter.
-    gboolean on = gtk_check_menu_item_get_active(frame->view_none_item);
-    if (on) {
-      gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
-      gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
-      gtk_widget_set_visible(frame->gauge_frame, 0);
-
     }
     lingot_gui_mainframe_update_gauge_area_tooltip(frame);
 }
@@ -197,8 +194,6 @@ void lingot_gui_mainframe_callback_view_strobe_disc(GtkWidget* w, lingot_main_fr
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_strobe_disc_item);
     if (on) {
-      gtk_widget_set_visible(frame->gauge_frame, 1);
-      gtk_check_menu_item_set_active(frame->view_none_item, 0);
       gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
     }
     lingot_gui_mainframe_update_gauge_area_tooltip(frame);
@@ -540,7 +535,7 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
 
     frame->view_spectrum_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "spectrum_item"));
     frame->view_gauge_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "gauge_item"));
-    frame->view_none_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "none_item"));
+    frame->view_deviation_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "deviation_item"));
     frame->view_strobe_disc_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "strobe_disc_item"));
     frame->labelsbox = GTK_WIDGET(gtk_builder_get_object(builder, "labelsbox"));
     frame->horizontal_paned = GTK_PANED(gtk_builder_get_object(builder, "horizontal_paned"));
@@ -557,14 +552,17 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
     g_signal_connect(frame->view_spectrum_item,
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_spectrum),
                      frame);
+   g_signal_connect(frame->view_spectrum_item,
+                    "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_deviation),
+                    frame);
     g_signal_connect(frame->view_gauge_item,
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_gauge),
                      frame);
     g_signal_connect(frame->view_strobe_disc_item,
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_strobe_disc),
                      frame);
-    g_signal_connect(frame->view_none_item,
-                    "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_none),
+    g_signal_connect(frame->view_deviation_item,
+                    "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_deviation),
                     frame);
     g_signal_connect(gtk_builder_get_object(builder, "open_config_item"),
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_open_config),
@@ -591,7 +589,7 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
 
     gtk_check_menu_item_set_active(frame->view_spectrum_item, ui_settings.spectrum_visible);
     gtk_check_menu_item_set_active(frame->view_gauge_item, ui_settings.gauge_visible);
-    gtk_check_menu_item_set_active(frame->view_none_item, ui_settings.none_visible);
+    gtk_check_menu_item_set_active(frame->view_deviation_item, ui_settings.deviation_visible);
 
 
     if (ui_settings.win_width > 0) {

--- a/src/lingot-gui-mainframe.c
+++ b/src/lingot-gui-mainframe.c
@@ -172,14 +172,31 @@ void lingot_gui_mainframe_update_gauge_area_tooltip(lingot_main_frame_t* frame) 
 void lingot_gui_mainframe_callback_view_gauge(GtkWidget* w, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_gauge_item);
-    gtk_check_menu_item_set_active(frame->view_strobe_disc_item, !on);
+    if (on) {
+      gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
+      gtk_check_menu_item_set_active(frame->view_none_item, 0);
+    }
+    lingot_gui_mainframe_update_gauge_area_tooltip(frame);
+}
+
+
+void lingot_gui_mainframe_callback_view_none(GtkWidget* w, lingot_main_frame_t* frame) {
+    (void)w;                //  Unused parameter.
+    gboolean on = gtk_check_menu_item_get_active(frame->view_none_item);
+    if (on) {
+      gtk_check_menu_item_set_active(frame->view_strobe_disc_item, 0);
+      gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
+    }
     lingot_gui_mainframe_update_gauge_area_tooltip(frame);
 }
 
 void lingot_gui_mainframe_callback_view_strobe_disc(GtkWidget* w, lingot_main_frame_t* frame) {
     (void)w;                //  Unused parameter.
     gboolean on = gtk_check_menu_item_get_active(frame->view_strobe_disc_item);
-    gtk_check_menu_item_set_active(frame->view_gauge_item, !on);
+    if (on) {
+      gtk_check_menu_item_set_active(frame->view_none_item, 0);
+      gtk_check_menu_item_set_active(frame->view_gauge_item, 0);
+    }
     lingot_gui_mainframe_update_gauge_area_tooltip(frame);
 }
 
@@ -409,9 +426,10 @@ gboolean lingot_gui_gauge_strobe_disc_redraw(GtkWidget *w, cairo_t *cr, lingot_m
 //    lingot_gui_mainframe_callback_show(w, frame);
     if (gtk_check_menu_item_get_active(frame->view_gauge_item)) {
         lingot_gui_gauge_redraw(w, cr, frame);
-    } else{
+    } else if (gtk_check_menu_item_get_active(frame->view_strobe_disc_item)){
         lingot_gui_strobe_disc_redraw(w, cr, frame);
     }
+
     return FALSE;
 }
 
@@ -516,6 +534,7 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
     frame->spectrum_frame = GTK_WIDGET(gtk_builder_get_object(builder, "spectrum_frame"));
     frame->view_spectrum_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "spectrum_item"));
     frame->view_gauge_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "gauge_item"));
+    frame->view_none_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "none_item"));
     frame->view_strobe_disc_item = GTK_CHECK_MENU_ITEM(gtk_builder_get_object(builder, "strobe_disc_item"));
     frame->labelsbox = GTK_WIDGET(gtk_builder_get_object(builder, "labelsbox"));
     frame->horizontal_paned = GTK_PANED(gtk_builder_get_object(builder, "horizontal_paned"));
@@ -538,6 +557,9 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
     g_signal_connect(frame->view_strobe_disc_item,
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_strobe_disc),
                      frame);
+    g_signal_connect(frame->view_none_item,
+                    "activate", G_CALLBACK(lingot_gui_mainframe_callback_view_none),
+                    frame);
     g_signal_connect(gtk_builder_get_object(builder, "open_config_item"),
                      "activate", G_CALLBACK(lingot_gui_mainframe_callback_open_config),
                      frame);
@@ -563,6 +585,8 @@ lingot_main_frame_t* lingot_gui_mainframe_create() {
 
     gtk_check_menu_item_set_active(frame->view_spectrum_item, ui_settings.spectrum_visible);
     gtk_check_menu_item_set_active(frame->view_gauge_item, ui_settings.gauge_visible);
+    gtk_check_menu_item_set_active(frame->view_none_item, ui_settings.none_visible);
+
 
     if (ui_settings.win_width > 0) {
         gtk_window_resize(frame->win, ui_settings.win_width, ui_settings.win_height);

--- a/src/lingot-gui-mainframe.glade
+++ b/src/lingot-gui-mainframe.glade
@@ -126,17 +126,17 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="none_item">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Show Nothing</property>
-                        <property name="draw-as-radio">True</property>
-                      </object>
-                    </child>
-                    <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="deviation_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Show Deviation</property>
+                        <property name="active">True</property>
                       </object>
                     </child>
                     <child>

--- a/src/lingot-gui-mainframe.glade
+++ b/src/lingot-gui-mainframe.glade
@@ -126,6 +126,14 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="none_item">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Show Nothing</property>
+                        <property name="draw-as-radio">True</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>

--- a/src/lingot-gui-mainframe.h
+++ b/src/lingot-gui-mainframe.h
@@ -43,7 +43,8 @@ typedef struct _lingot_main_frame_t {
     GtkCheckMenuItem* view_spectrum_item;
     GtkCheckMenuItem* view_gauge_item;
     GtkCheckMenuItem* view_strobe_disc_item;
-    GtkCheckMenuItem* view_none_item;
+    GtkCheckMenuItem* view_deviation_item;
+    GtkWidget* gauge_frame;
     GtkWidget* spectrum_frame;
 
     GtkWidget* labelsbox;

--- a/src/lingot-gui-mainframe.h
+++ b/src/lingot-gui-mainframe.h
@@ -43,6 +43,7 @@ typedef struct _lingot_main_frame_t {
     GtkCheckMenuItem* view_spectrum_item;
     GtkCheckMenuItem* view_gauge_item;
     GtkCheckMenuItem* view_strobe_disc_item;
+    GtkCheckMenuItem* view_none_item;
     GtkWidget* spectrum_frame;
 
     GtkWidget* labelsbox;

--- a/src/lingot-io-ui-settings.h
+++ b/src/lingot-io-ui-settings.h
@@ -52,7 +52,7 @@ typedef struct {
     // visible / invisible widgets
     int spectrum_visible;
     int gauge_visible;
-    int none_visible;
+    int deviation_visible;
 
     // position and size of main window
     int win_width;

--- a/src/lingot-io-ui-settings.h
+++ b/src/lingot-io-ui-settings.h
@@ -52,6 +52,7 @@ typedef struct {
     // visible / invisible widgets
     int spectrum_visible;
     int gauge_visible;
+    int none_visible;
 
     // position and size of main window
     int win_width;


### PR DESCRIPTION
I've modified the spectrum graph so that it only displays the range, 
that is between the minimum and maximum frequency of the instrument.

I've added a 5% margin on each side so you can see if you are under the minimum; or over the maximum note.

This allows better visibility if the application window is narrow, and makes it easier to distinguish the played note from the fundamental note.

I'm not sure if this is a change you needed, but if so, here is the PR for it.