### PR TITLE
Complement org.nongnu.lingot.appdata.xml

### DIFF
--- a/org.nongnu.lingot.appdata.xml
+++ b/org.nongnu.lingot.appdata.xml
@@ -41,9 +41,16 @@
     </screenshots>
 
     <url type="homepage">https://www.nongnu.org/lingot/</url>
+    <url type="bugtracker">https://github.com/ibancg/lingot/issues/</url>
+    <url type="vcs-browser">https://github.com/ibancg/lingot</url>
 
     <update_contact>ibancg_AT_gmail.com</update_contact>
-
+    <categories>
+        <category>GTK</category>
+        <category>GNOME</category>
+        <category>Education</category>
+        <category>Music</category>
+    </categories>
     <provides>
         <binary>lingot</binary>
     </provides>


### PR DESCRIPTION
Based on what is already available in the [LinuxPhoneApps listing](https://linuxphoneapps.org/apps/org.nongnu.lingot/) I added some missing metainfo:

* Adds vcs-browser url
* Adds bugtracker url
* Adds categories